### PR TITLE
Swipe remove with in-place undo and "leave-behind" from enhancement issue #43 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,9 @@
             android:name=".SimpleItemListActivity"
             android:label="@string/sample_simple_item_list" />
         <activity
+            android:name=".SwipeListActivity"
+            android:label="@string/sample_swipe_list" />
+        <activity
             android:name=".ImageListActivity"
             android:label="@string/sample_image_list" />
         <activity

--- a/app/src/main/java/com/mikepenz/fastadapter/app/SampleActivity.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/SampleActivity.java
@@ -75,6 +75,7 @@ public class SampleActivity extends AppCompatActivity {
                         new PrimaryDrawerItem().withName(R.string.sample_multi_generic_item).withDescription(R.string.sample_multi_generic_item_descr).withSelectable(false).withIdentifier(9).withIcon(MaterialDesignIconic.Icon.gmi_format_list_numbered),
                         new PrimaryDrawerItem().withName(R.string.sample_checkbox_item).withDescription(R.string.sample_checkbox_item_descr).withSelectable(false).withIdentifier(10).withIcon(CommunityMaterial.Icon.cmd_checkbox_marked),
                         new PrimaryDrawerItem().withName(R.string.sample_radiobutton_item).withDescription(R.string.sample_radiobutton_item_descr).withSelectable(false).withIdentifier(11).withIcon(CommunityMaterial.Icon.cmd_radiobox_marked),
+                        new PrimaryDrawerItem().withName(R.string.sample_swipe_list).withDescription(R.string.sample_swipe_list_descr).withSelectable(false).withIdentifier(12).withIcon(MaterialDesignIconic.Icon.gmi_format_align_left),
                         new DividerDrawerItem(),
                         new PrimaryDrawerItem().withName(R.string.open_source).withSelectable(false).withIdentifier(100).withIcon(MaterialDesignIconic.Icon.gmi_github)
                 )
@@ -105,6 +106,8 @@ public class SampleActivity extends AppCompatActivity {
                                 intent = new Intent(SampleActivity.this, CheckBoxSampleActivity.class);
                             } else if (drawerItem.getIdentifier() == 11) {
                                 intent = new Intent(SampleActivity.this, RadioButtonSampleActivity.class);
+                            } else if (drawerItem.getIdentifier() == 12) {
+                                intent = new Intent(SampleActivity.this, SwipeListActivity.class);
                             } else if (drawerItem.getIdentifier() == 100) {
                                 intent = new LibsBuilder()
                                         .withFields(R.string.class.getFields())

--- a/app/src/main/java/com/mikepenz/fastadapter/app/SwipeListActivity.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/SwipeListActivity.java
@@ -23,7 +23,6 @@ import com.mikepenz.fastadapter.FastAdapter;
 import com.mikepenz.fastadapter.IAdapter;
 import com.mikepenz.fastadapter.IItemAdapter;
 import com.mikepenz.fastadapter.adapters.FastItemAdapter;
-import com.mikepenz.fastadapter.app.items.SampleItem;
 import com.mikepenz.fastadapter.app.items.SwipeableItem;
 import com.mikepenz.fastadapter.app.swipe.SimpleSwipeCallback;
 import com.mikepenz.fastadapter.app.swipe.SimpleSwipeDragCallback;
@@ -105,12 +104,25 @@ public class SwipeListActivity extends AppCompatActivity implements ItemTouchCal
 
         //add drag and drop for item
         //and add swipe as well
-        Drawable leaveBehindDrawable = new IconicsDrawable(this)
+        Drawable leaveBehindDrawableLeft = new IconicsDrawable(this)
                 .icon(MaterialDesignIconic.Icon.gmi_delete)
                 .color(Color.WHITE)
                 .sizeDp(24);
+        Drawable leaveBehindDrawableRight = new IconicsDrawable(this)
+                .icon(MaterialDesignIconic.Icon.gmi_archive)
+                .color(Color.WHITE)
+                .sizeDp(24);
 
-        touchCallback = new SimpleSwipeDragCallback(this, this, leaveBehindDrawable, ItemTouchHelper.LEFT, ContextCompat.getColor(this, R.color.md_red_900));
+        touchCallback = new SimpleSwipeDragCallback(
+                this,
+                this,
+                leaveBehindDrawableLeft,
+                ItemTouchHelper.LEFT,
+                ContextCompat.getColor(this, R.color.md_red_900)
+        )
+                .withBackgroundSwipeRight(ContextCompat.getColor(this, R.color.md_blue_900))
+                .withLeaveBehindSwipeRight(leaveBehindDrawableRight);
+
         touchHelper = new ItemTouchHelper(touchCallback); // Create ItemTouchHelper and pass with parameter the SimpleDragCallback
         touchHelper.attachToRecyclerView(recyclerView); // Attach ItemTouchHelper to RecyclerView
 
@@ -189,16 +201,19 @@ public class SwipeListActivity extends AppCompatActivity implements ItemTouchCal
         //C) update item, set "read" if an email etc
 
         // -- Option 2: Delayed action --
-        //Possibly make a general case of this?
         final SwipeableItem item = fastItemAdapter.getItem(position);
         item.setSwipedDirection(direction);
 
+        // This can vary depending on direction but remove & archive simulated here both results in
+        // removal from list
         final Runnable removeRunnable = new Runnable() {
             @Override
             public void run() {
-                int position = fastItemAdapter.getAdapterPosition(item);
                 item.setSwipedAction(null);
-                fastItemAdapter.remove(position);
+                int position = fastItemAdapter.getAdapterPosition(item);
+                if (position != RecyclerView.NO_POSITION) {
+                    fastItemAdapter.remove(position);
+                }
             }
         };
         final View rv = findViewById(R.id.rv);
@@ -210,11 +225,15 @@ public class SwipeListActivity extends AppCompatActivity implements ItemTouchCal
                 rv.removeCallbacks(removeRunnable);
                 item.setSwipedDirection(0);
                 int position = fastItemAdapter.getAdapterPosition(item);
-                fastItemAdapter.notifyItemChanged(position);
+                if (position != RecyclerView.NO_POSITION) {
+                    fastItemAdapter.notifyItemChanged(position);
+                }
             }
         });
 
         fastItemAdapter.notifyItemChanged(position);
+
+        //TODO can this above be made more generic, along with the support in the item?
     }
 
 }

--- a/app/src/main/java/com/mikepenz/fastadapter/app/SwipeListActivity.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/SwipeListActivity.java
@@ -1,0 +1,207 @@
+package com.mikepenz.fastadapter.app;
+
+import android.graphics.Color;
+import android.os.Build;
+import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.DefaultItemAnimator;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.SearchView;
+import android.support.v7.widget.Toolbar;
+import android.support.v7.widget.helper.ItemTouchHelper;
+import android.text.TextUtils;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.Toast;
+
+import com.mikepenz.fastadapter.FastAdapter;
+import com.mikepenz.fastadapter.IAdapter;
+import com.mikepenz.fastadapter.IItemAdapter;
+import com.mikepenz.fastadapter.adapters.FastItemAdapter;
+import com.mikepenz.fastadapter.app.adapter.FastScrollIndicatorAdapter;
+import com.mikepenz.fastadapter.app.items.SampleItem;
+import com.mikepenz.fastadapter.app.swipe.SimpleSwipeCallback;
+import com.mikepenz.fastadapter.app.swipe.SimpleSwipeDragCallback;
+import com.mikepenz.fastadapter.drag.ItemTouchCallback;
+import com.mikepenz.fastadapter.drag.SimpleDragCallback;
+import com.mikepenz.fastadapter.helpers.UndoHelper;
+import com.mikepenz.materialize.MaterializeBuilder;
+import com.turingtechnologies.materialscrollbar.AlphabetIndicator;
+import com.turingtechnologies.materialscrollbar.DragScrollBar;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+public class SwipeListActivity extends AppCompatActivity implements ItemTouchCallback, SimpleSwipeCallback.ItemSwipeCallback {
+    private static final String[] ALPHABET = new String[]{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"};
+
+    //save our FastAdapter
+    private FastItemAdapter<SampleItem> fastItemAdapter;
+
+    //drag & drop
+    private SimpleDragCallback touchCallback;
+    private ItemTouchHelper touchHelper;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        findViewById(android.R.id.content).setSystemUiVisibility(findViewById(android.R.id.content).getSystemUiVisibility() | View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_sample);
+
+        // Handle Toolbar
+        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+
+
+        //style our ui
+        new MaterializeBuilder().withActivity(this).build();
+
+        //create our FastAdapter which will manage everything
+        fastItemAdapter = new FastItemAdapter<>();
+
+        //configure our fastAdapter
+        fastItemAdapter.withOnClickListener(new FastAdapter.OnClickListener<SampleItem>() {
+            @Override
+            public boolean onClick(View v, IAdapter<SampleItem> adapter, SampleItem item, int position) {
+                Toast.makeText(v.getContext(), (item).name.getText(v.getContext()), Toast.LENGTH_LONG).show();
+                return false;
+            }
+        });
+
+        //configure the itemAdapter
+        fastItemAdapter.withFilterPredicate(new IItemAdapter.Predicate<SampleItem>() {
+            @Override
+            public boolean filter(SampleItem item, CharSequence constraint) {
+                //return true if we should filter it out
+                //return false to keep it
+                return !item.name.getText().toLowerCase().contains(constraint.toString().toLowerCase());
+            }
+        });
+
+        //get our recyclerView and do basic setup
+        RecyclerView recyclerView = (RecyclerView) findViewById(R.id.rv);
+        recyclerView.setLayoutManager(new LinearLayoutManager(this));
+        recyclerView.setItemAnimator(new DefaultItemAnimator());
+        recyclerView.setAdapter(fastItemAdapter);
+
+        //fill with some sample data
+        int x = 0;
+        List<SampleItem> items = new ArrayList<>();
+        for (String s : ALPHABET) {
+            int count = new Random().nextInt(20);
+            for (int i = 1; i <= count; i++) {
+                items.add(new SampleItem().withName(s + " Test " + x).withIdentifier(100 + x));
+                x++;
+            }
+        }
+        fastItemAdapter.add(items);
+
+
+        //add drag and drop for item
+        //and add swipe as well
+        touchCallback = new SimpleSwipeDragCallback(this, this, ItemTouchHelper.LEFT, Color.GREEN);
+        touchHelper = new ItemTouchHelper(touchCallback); // Create ItemTouchHelper and pass with parameter the SimpleDragCallback
+        touchHelper.attachToRecyclerView(recyclerView); // Attach ItemTouchHelper to RecyclerView
+
+        //restore selections (this has to be done after the items were added
+        fastItemAdapter.withSavedInstanceState(savedInstanceState);
+
+        //set the back arrow in the toolbar
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        getSupportActionBar().setHomeButtonEnabled(false);
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        //add the values which need to be saved from the adapter to the bundle
+        outState = fastItemAdapter.saveInstanceState(outState);
+        super.onSaveInstanceState(outState);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        //handle the click on the back arrow click
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                onBackPressed();
+                return true;
+
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+    }
+
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        // Inflate the menu items for use in the action bar
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.search, menu);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            final SearchView searchView = (SearchView) menu.findItem(R.id.search).getActionView();
+            searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
+                @Override
+                public boolean onQueryTextSubmit(String s) {
+                    touchCallback.setIsDragEnabled(false);
+                    fastItemAdapter.filter(s);
+                    return true;
+                }
+
+
+                @Override
+                public boolean onQueryTextChange(String s) {
+                    fastItemAdapter.filter(s);
+                    touchCallback.setIsDragEnabled(TextUtils.isEmpty(s));
+                    return true;
+                }
+            });
+        } else {
+            menu.findItem(R.id.search).setVisible(false);
+        }
+
+        return super.onCreateOptionsMenu(menu);
+    }
+
+    @Override
+    public boolean itemTouchOnMove(int oldPosition, int newPosition) {
+        Collections.swap(fastItemAdapter.getAdapterItems(), oldPosition, newPosition); // change position
+        fastItemAdapter.notifyAdapterItemMoved(oldPosition, newPosition);
+        return true;
+    }
+
+    @Override
+    public void itemSwiped(final int position, int direction) {
+        // -- Option 1: Direct action --
+        //do something when swiped such as: remove, select, ...
+        //fastItemAdapter.select(position);
+        //fastItemAdapter.remove(position);
+
+        // -- Option 2: Delayed action --
+        //Currently just showing example of modifying current item, could swap it out, or
+        //set part of the layout as GONE and another as VISIBLE
+        //Possibly make a general case of this?
+        fastItemAdapter.getItem(position).withDescription("").withName("Swiped, removing...");
+        fastItemAdapter.notifyItemChanged(position);
+
+        Runnable removeRunnable = new Runnable() {
+            @Override
+            public void run() {
+                fastItemAdapter.remove(position);
+            }
+        };
+        View rv = findViewById(R.id.rv);
+        rv.postDelayed(removeRunnable, 3000);
+
+        //for undo, add an onClickListener to something (button, image, text) which removes this
+        //runnable from the message queue (reset the ui as well!)
+        //rv.removeCallbacks(removeRunnable);
+        //fastItemAdapter.notifyItemChanged(position);
+    }
+
+}

--- a/app/src/main/java/com/mikepenz/fastadapter/app/SwipeListActivity.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/SwipeListActivity.java
@@ -176,7 +176,7 @@ public class SwipeListActivity extends AppCompatActivity implements ItemTouchCal
     }
 
     @Override
-    public void itemSwiped(final int position, int direction) {
+    public void itemSwiped(int position, int direction) {
         // -- Option 1: Direct action --
         //do something when swiped such as: remove, select, ...
         //fastItemAdapter.select(position);
@@ -186,12 +186,14 @@ public class SwipeListActivity extends AppCompatActivity implements ItemTouchCal
         //Currently just showing example of modifying current item, could swap it out, or
         //set part of the layout as GONE and another as VISIBLE
         //Possibly make a general case of this?
-        fastItemAdapter.getItem(position).withDescription("").withName("Swiped, removing...");
+        final SampleItem item = fastItemAdapter.getItem(position);
+        item.withDescription("").withName("Swiped, removing...");
         fastItemAdapter.notifyItemChanged(position);
 
         Runnable removeRunnable = new Runnable() {
             @Override
             public void run() {
+                int position = fastItemAdapter.getAdapterPosition(item);
                 fastItemAdapter.remove(position);
             }
         };

--- a/app/src/main/java/com/mikepenz/fastadapter/app/SwipeListActivity.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/SwipeListActivity.java
@@ -1,9 +1,9 @@
 package com.mikepenz.fastadapter.app;
 
 import android.graphics.Color;
+import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Bundle;
-import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.LinearLayoutManager;
@@ -22,16 +22,14 @@ import com.mikepenz.fastadapter.FastAdapter;
 import com.mikepenz.fastadapter.IAdapter;
 import com.mikepenz.fastadapter.IItemAdapter;
 import com.mikepenz.fastadapter.adapters.FastItemAdapter;
-import com.mikepenz.fastadapter.app.adapter.FastScrollIndicatorAdapter;
 import com.mikepenz.fastadapter.app.items.SampleItem;
 import com.mikepenz.fastadapter.app.swipe.SimpleSwipeCallback;
 import com.mikepenz.fastadapter.app.swipe.SimpleSwipeDragCallback;
 import com.mikepenz.fastadapter.drag.ItemTouchCallback;
 import com.mikepenz.fastadapter.drag.SimpleDragCallback;
-import com.mikepenz.fastadapter.helpers.UndoHelper;
+import com.mikepenz.iconics.IconicsDrawable;
+import com.mikepenz.material_design_iconic_typeface_library.MaterialDesignIconic;
 import com.mikepenz.materialize.MaterializeBuilder;
-import com.turingtechnologies.materialscrollbar.AlphabetIndicator;
-import com.turingtechnologies.materialscrollbar.DragScrollBar;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -105,7 +103,12 @@ public class SwipeListActivity extends AppCompatActivity implements ItemTouchCal
 
         //add drag and drop for item
         //and add swipe as well
-        touchCallback = new SimpleSwipeDragCallback(this, this, ItemTouchHelper.LEFT, Color.GREEN);
+        Drawable leaveBehindDrawable = new IconicsDrawable(this)
+                .icon(MaterialDesignIconic.Icon.gmi_delete)
+                .color(Color.WHITE)
+                .sizeDp(24);
+
+        touchCallback = new SimpleSwipeDragCallback(this, this, leaveBehindDrawable, ItemTouchHelper.LEFT, Color.RED);
         touchHelper = new ItemTouchHelper(touchCallback); // Create ItemTouchHelper and pass with parameter the SimpleDragCallback
         touchHelper.attachToRecyclerView(recyclerView); // Attach ItemTouchHelper to RecyclerView
 

--- a/app/src/main/java/com/mikepenz/fastadapter/app/items/SwipeableItem.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/items/SwipeableItem.java
@@ -1,0 +1,166 @@
+package com.mikepenz.fastadapter.app.items;
+
+import android.support.annotation.StringRes;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.widget.TextView;
+
+import com.mikepenz.fastadapter.app.R;
+import com.mikepenz.fastadapter.items.AbstractItem;
+import com.mikepenz.fastadapter.utils.ViewHolderFactory;
+import com.mikepenz.materialdrawer.holder.StringHolder;
+
+import butterknife.Bind;
+import butterknife.ButterKnife;
+
+/**
+ * Created by Mattias on 2016-02-15.
+ */
+public class SwipeableItem extends AbstractItem<SwipeableItem, SwipeableItem.ViewHolder> {
+    //the static ViewHolderFactory which will be used to generate the ViewHolder for this Item
+    private static final ViewHolderFactory<? extends ViewHolder> FACTORY = new ItemFactory();
+
+    public StringHolder name;
+    public StringHolder description;
+
+    public StringHolder undoTextSwipeFromRight;
+    public StringHolder undoTextSwipeFromLeft;
+    public StringHolder undoTextSwipeFromTop;
+    public StringHolder undoTextSwipeFromBottom;
+
+    public int swipedDirection;
+    private Runnable swipedAction;
+
+    public SwipeableItem withName(String Name) {
+        this.name = new StringHolder(Name);
+        return this;
+    }
+
+    public SwipeableItem withName(@StringRes int NameRes) {
+        this.name = new StringHolder(NameRes);
+        return this;
+    }
+
+    public SwipeableItem withDescription(String description) {
+        this.description = new StringHolder(description);
+        return this;
+    }
+
+    public SwipeableItem withDescription(@StringRes int descriptionRes) {
+        this.description = new StringHolder(descriptionRes);
+        return this;
+    }
+
+    public void setSwipedDirection(int swipedDirection) {
+        this.swipedDirection = swipedDirection;
+    }
+
+    public void setSwipedAction(Runnable action) {
+        this.swipedAction = action;
+    }
+
+    /**
+     * defines the type defining this item. must be unique. preferably an id
+     *
+     * @return the type
+     */
+    @Override
+    public int getType() {
+        return R.id.fastadapter_swipable_item_id;
+    }
+
+    /**
+     * defines the layout which will be used for this item in the list
+     *
+     * @return the layout for this item
+     */
+    @Override
+    public int getLayoutRes() {
+        return R.layout.swipeable_item;
+    }
+
+    /**
+     * binds the data of this item onto the viewHolder
+     *
+     * @param viewHolder the viewHolder of this item
+     */
+    @Override
+    public void bindView(ViewHolder viewHolder) {
+        super.bindView(viewHolder);
+
+        //set the text for the name
+        StringHolder.applyTo(name, viewHolder.name);
+        //set the text for the description or hide
+        StringHolder.applyToOrHide(description, viewHolder.description);
+
+        viewHolder.swipeResultContent.setVisibility(swipedDirection != 0 ? View.VISIBLE : View.GONE);
+        viewHolder.itemContent.setVisibility(swipedDirection != 0 ? View.GONE : View.VISIBLE);
+
+        CharSequence swipedAction = null;
+        CharSequence swipedText = null;
+        if (swipedDirection != 0) {
+            //FIXME left, right, top, bottom, ...
+            swipedAction = viewHolder.itemView.getContext().getString(R.string.action_undo);
+            swipedText = "Swiped";
+        }
+        viewHolder.swipedAction.setText(swipedAction == null ? "" : swipedAction);
+        viewHolder.swipedText.setText(swipedText == null ? "" : swipedText);
+        viewHolder.swipedActionRunnable = this.swipedAction;
+    }
+
+
+    /**
+     * our ItemFactory implementation which creates the ViewHolder for our adapter.
+     * It is highly recommended to implement a ViewHolderFactory as it is 0-1ms faster for ViewHolder creation,
+     * and it is also many many times more efficient if you define custom listeners on views within your item.
+     */
+    protected static class ItemFactory implements ViewHolderFactory<ViewHolder> {
+        public ViewHolder create(View v) {
+            return new ViewHolder(v);
+        }
+    }
+
+    /**
+     * return our ViewHolderFactory implementation here
+     *
+     * @return
+     */
+    @Override
+    public ViewHolderFactory<? extends ViewHolder> getFactory() {
+        return FACTORY;
+    }
+
+
+    /**
+     * our ViewHolder
+     */
+    protected static class ViewHolder extends RecyclerView.ViewHolder {
+        @Bind(R.id.material_drawer_name)
+        TextView name;
+        @Bind(R.id.material_drawer_description)
+        TextView description;
+        @Bind(R.id.swipe_result_content)
+        View swipeResultContent;
+        @Bind(R.id.item_content)
+        View itemContent;
+        @Bind(R.id.swiped_text)
+        TextView swipedText;
+        @Bind(R.id.swiped_action)
+        TextView swipedAction;
+
+        public Runnable swipedActionRunnable;
+
+        public ViewHolder(View view) {
+            super(view);
+            ButterKnife.bind(this, view);
+            swipedAction.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    if (swipedActionRunnable != null) {
+                        swipedActionRunnable.run();
+                    }
+                }
+            });
+        }
+    }
+}

--- a/app/src/main/java/com/mikepenz/fastadapter/app/items/SwipeableItem.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/items/SwipeableItem.java
@@ -1,7 +1,9 @@
 package com.mikepenz.fastadapter.app.items;
 
 import android.support.annotation.StringRes;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.helper.ItemTouchHelper;
 import android.view.View;
 import android.widget.TextView;
 
@@ -99,9 +101,9 @@ public class SwipeableItem extends AbstractItem<SwipeableItem, SwipeableItem.Vie
         CharSequence swipedAction = null;
         CharSequence swipedText = null;
         if (swipedDirection != 0) {
-            //FIXME left, right, top, bottom, ...
             swipedAction = viewHolder.itemView.getContext().getString(R.string.action_undo);
-            swipedText = "Swiped";
+            swipedText = swipedDirection == ItemTouchHelper.LEFT ? "Removed" : "Archived";
+            viewHolder.swipeResultContent.setBackgroundColor(ContextCompat.getColor(viewHolder.itemView.getContext(), swipedDirection == ItemTouchHelper.LEFT ? R.color.md_red_900 : R.color.md_blue_900));
         }
         viewHolder.swipedAction.setText(swipedAction == null ? "" : swipedAction);
         viewHolder.swipedText.setText(swipedText == null ? "" : swipedText);

--- a/app/src/main/java/com/mikepenz/fastadapter/app/swipe/SimpleSwipeCallback.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/swipe/SimpleSwipeCallback.java
@@ -1,0 +1,76 @@
+package com.mikepenz.fastadapter.app.swipe;
+
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.support.annotation.ColorInt;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.helper.ItemTouchHelper;
+import android.view.View;
+
+/**
+ * Created by Mattias on 2016-02-13.
+ */
+public class SimpleSwipeCallback extends ItemTouchHelper.SimpleCallback {
+
+    public interface ItemSwipeCallback {
+
+        /**
+         * Called when an item has been swiped
+         *
+         * @param position  position of item in the adapter
+         * @param direction direction the item was swiped
+         * @return true if moved otherwise false
+         */
+        void itemSwiped(int position, int direction);
+    }
+
+    private final ItemSwipeCallback itemSwipeCallback;
+    private final int bgColor;
+    private Paint bgPaint;
+
+    public SimpleSwipeCallback(SimpleSwipeCallback.ItemSwipeCallback itemSwipeCallback) {
+        this(itemSwipeCallback, ItemTouchHelper.LEFT);
+    }
+
+    public SimpleSwipeCallback(SimpleSwipeCallback.ItemSwipeCallback itemSwipeCallback, int swipeDirs) {
+        this(itemSwipeCallback, swipeDirs, Color.RED);
+    }
+
+    public SimpleSwipeCallback(SimpleSwipeCallback.ItemSwipeCallback itemSwipeCallback, int swipeDirs, @ColorInt int bgColor) {
+        super(0, swipeDirs);
+        this.itemSwipeCallback = itemSwipeCallback;
+        this.bgColor = bgColor;
+    }
+
+
+    @Override
+    public void onSwiped(RecyclerView.ViewHolder viewHolder, int direction) {
+        int position = viewHolder.getAdapterPosition();
+        if (position != RecyclerView.NO_POSITION) {
+            itemSwipeCallback.itemSwiped(position, direction);
+        }
+    }
+
+    @Override
+    public boolean onMove(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder, RecyclerView.ViewHolder target) {
+        // not enabled
+        return false;
+    }
+
+    @Override
+    public void onChildDraw(Canvas c, RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder, float dX, float dY, int actionState, boolean isCurrentlyActive) {
+        View itemView = viewHolder.itemView;
+        if (viewHolder.getAdapterPosition() == RecyclerView.NO_POSITION) {
+            return;
+        }
+        if (Math.abs(dX) > Math.abs(dY)) {
+            if (bgPaint == null) {
+                bgPaint = new Paint();
+                bgPaint.setColor(bgColor);
+            }
+            c.drawRect(itemView.getRight() + (int) dX, itemView.getTop(), itemView.getRight(), itemView.getBottom(), bgPaint);
+        }
+        super.onChildDraw(c, recyclerView, viewHolder, dX, dY, actionState, isCurrentlyActive);
+    }
+}

--- a/app/src/main/java/com/mikepenz/fastadapter/app/swipe/SimpleSwipeCallback.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/swipe/SimpleSwipeCallback.java
@@ -3,10 +3,12 @@ package com.mikepenz.fastadapter.app.swipe;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
+import android.graphics.drawable.Drawable;
 import android.support.annotation.ColorInt;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.helper.ItemTouchHelper;
 import android.view.View;
+
 
 /**
  * Created by Mattias on 2016-02-13.
@@ -23,23 +25,29 @@ public class SimpleSwipeCallback extends ItemTouchHelper.SimpleCallback {
          * @return true if moved otherwise false
          */
         void itemSwiped(int position, int direction);
+
     }
 
     private final ItemSwipeCallback itemSwipeCallback;
+
     private final int bgColor;
+
+    private Drawable leaveBehindDrawable;
     private Paint bgPaint;
+    private int horizMargin;
 
-    public SimpleSwipeCallback(SimpleSwipeCallback.ItemSwipeCallback itemSwipeCallback) {
-        this(itemSwipeCallback, ItemTouchHelper.LEFT);
+    public SimpleSwipeCallback(SimpleSwipeCallback.ItemSwipeCallback itemSwipeCallback, Drawable leaveBehindDrawable) {
+        this(itemSwipeCallback, leaveBehindDrawable, ItemTouchHelper.LEFT);
     }
 
-    public SimpleSwipeCallback(SimpleSwipeCallback.ItemSwipeCallback itemSwipeCallback, int swipeDirs) {
-        this(itemSwipeCallback, swipeDirs, Color.RED);
+    public SimpleSwipeCallback(SimpleSwipeCallback.ItemSwipeCallback itemSwipeCallback, Drawable leaveBehindDrawable, int swipeDirs) {
+        this(itemSwipeCallback, leaveBehindDrawable, swipeDirs, Color.RED);
     }
 
-    public SimpleSwipeCallback(SimpleSwipeCallback.ItemSwipeCallback itemSwipeCallback, int swipeDirs, @ColorInt int bgColor) {
+    public SimpleSwipeCallback(ItemSwipeCallback itemSwipeCallback, Drawable leaveBehindDrawable, int swipeDirs, @ColorInt int bgColor) {
         super(0, swipeDirs);
         this.itemSwipeCallback = itemSwipeCallback;
+        this.leaveBehindDrawable = leaveBehindDrawable;
         this.bgColor = bgColor;
     }
 
@@ -58,6 +66,7 @@ public class SimpleSwipeCallback extends ItemTouchHelper.SimpleCallback {
         return false;
     }
 
+    //Inspired/modified from: https://github.com/nemanja-kovacevic/recycler-view-swipe-to-delete/blob/master/app/src/main/java/net/nemanjakovacevic/recyclerviewswipetodelete/MainActivity.java
     @Override
     public void onChildDraw(Canvas c, RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder, float dX, float dY, int actionState, boolean isCurrentlyActive) {
         View itemView = viewHolder.itemView;
@@ -68,8 +77,26 @@ public class SimpleSwipeCallback extends ItemTouchHelper.SimpleCallback {
             if (bgPaint == null) {
                 bgPaint = new Paint();
                 bgPaint.setColor(bgColor);
+                horizMargin = (int)(16 * recyclerView.getResources().getDisplayMetrics().density);
             }
-            c.drawRect(itemView.getRight() + (int) dX, itemView.getTop(), itemView.getRight(), itemView.getBottom(), bgPaint);
+
+            if (bgColor != Color.TRANSPARENT) {
+                c.drawRect(itemView.getRight() + (int) dX, itemView.getTop(), itemView.getRight(), itemView.getBottom(), bgPaint);
+            }
+
+            if (leaveBehindDrawable != null) {
+                int itemHeight = itemView.getBottom() - itemView.getTop();
+                int intrinsicWidth = leaveBehindDrawable.getIntrinsicWidth();
+                int intrinsicHeight = leaveBehindDrawable.getIntrinsicWidth();
+
+                int left = itemView.getRight() - horizMargin - intrinsicWidth;
+                int right = itemView.getRight() - horizMargin;
+                int top = itemView.getTop() + (itemHeight - intrinsicHeight)/2;
+                int bottom = top + intrinsicHeight;
+                leaveBehindDrawable.setBounds(left, top, right, bottom);
+
+                leaveBehindDrawable.draw(c);
+            }
         }
         super.onChildDraw(c, recyclerView, viewHolder, dX, dY, actionState, isCurrentlyActive);
     }

--- a/app/src/main/java/com/mikepenz/fastadapter/app/swipe/SimpleSwipeCallback.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/swipe/SimpleSwipeCallback.java
@@ -54,6 +54,8 @@ public class SimpleSwipeCallback extends ItemTouchHelper.SimpleCallback {
 
     @Override
     public void onSwiped(RecyclerView.ViewHolder viewHolder, int direction) {
+        viewHolder.itemView.setTranslationX(0);
+        viewHolder.itemView.setTranslationY(0);
         int position = viewHolder.getAdapterPosition();
         if (position != RecyclerView.NO_POSITION) {
             itemSwipeCallback.itemSwiped(position, direction);

--- a/app/src/main/java/com/mikepenz/fastadapter/app/swipe/SimpleSwipeDragCallback.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/swipe/SimpleSwipeDragCallback.java
@@ -1,0 +1,45 @@
+package com.mikepenz.fastadapter.app.swipe;
+
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.support.annotation.ColorInt;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.helper.ItemTouchHelper;
+
+import com.mikepenz.fastadapter.drag.ItemTouchCallback;
+import com.mikepenz.fastadapter.drag.SimpleDragCallback;
+
+/**
+ * Created by Mattias on 2016-02-13.
+ */
+public class SimpleSwipeDragCallback extends SimpleDragCallback {
+
+    private final SimpleSwipeCallback simpleSwipeCallback;
+
+    public SimpleSwipeDragCallback(ItemTouchCallback itemTouchCallback, SimpleSwipeCallback.ItemSwipeCallback itemSwipeCallback) {
+        this(itemTouchCallback, itemSwipeCallback, ItemTouchHelper.LEFT);
+    }
+
+    public SimpleSwipeDragCallback(ItemTouchCallback itemTouchCallback, SimpleSwipeCallback.ItemSwipeCallback itemSwipeCallback, int swipeDirs) {
+        this(itemTouchCallback, itemSwipeCallback, swipeDirs, Color.RED);
+    }
+
+    public SimpleSwipeDragCallback(ItemTouchCallback itemTouchCallback, SimpleSwipeCallback.ItemSwipeCallback itemSwipeCallback, int swipeDirs, @ColorInt int bgColor) {
+        super(itemTouchCallback);
+        setDefaultSwipeDirs(swipeDirs);
+        simpleSwipeCallback = new SimpleSwipeCallback(itemSwipeCallback, swipeDirs, bgColor);
+    }
+
+
+    @Override
+    public void onSwiped(RecyclerView.ViewHolder viewHolder, int direction) {
+        simpleSwipeCallback.onSwiped(viewHolder, direction);
+    }
+
+    @Override
+    public void onChildDraw(Canvas c, RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder, float dX, float dY, int actionState, boolean isCurrentlyActive) {
+        simpleSwipeCallback.onChildDraw(c, recyclerView, viewHolder, dX, dY, actionState, isCurrentlyActive);
+        //Happen to know that our direct parent class doesn't (currently) draw anything...
+        //super.onChildDraw(c, recyclerView, viewHolder, dX, dY, actionState, isCurrentlyActive);
+    }
+}

--- a/app/src/main/java/com/mikepenz/fastadapter/app/swipe/SimpleSwipeDragCallback.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/swipe/SimpleSwipeDragCallback.java
@@ -2,6 +2,7 @@ package com.mikepenz.fastadapter.app.swipe;
 
 import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.drawable.Drawable;
 import android.support.annotation.ColorInt;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.helper.ItemTouchHelper;
@@ -16,18 +17,18 @@ public class SimpleSwipeDragCallback extends SimpleDragCallback {
 
     private final SimpleSwipeCallback simpleSwipeCallback;
 
-    public SimpleSwipeDragCallback(ItemTouchCallback itemTouchCallback, SimpleSwipeCallback.ItemSwipeCallback itemSwipeCallback) {
-        this(itemTouchCallback, itemSwipeCallback, ItemTouchHelper.LEFT);
+    public SimpleSwipeDragCallback(ItemTouchCallback itemTouchCallback, SimpleSwipeCallback.ItemSwipeCallback itemSwipeCallback, Drawable leaveBehindDrawable) {
+        this(itemTouchCallback, itemSwipeCallback, leaveBehindDrawable, ItemTouchHelper.LEFT);
     }
 
-    public SimpleSwipeDragCallback(ItemTouchCallback itemTouchCallback, SimpleSwipeCallback.ItemSwipeCallback itemSwipeCallback, int swipeDirs) {
-        this(itemTouchCallback, itemSwipeCallback, swipeDirs, Color.RED);
+    public SimpleSwipeDragCallback(ItemTouchCallback itemTouchCallback, SimpleSwipeCallback.ItemSwipeCallback itemSwipeCallback, Drawable leaveBehindDrawable, int swipeDirs) {
+        this(itemTouchCallback, itemSwipeCallback, leaveBehindDrawable, swipeDirs, Color.RED);
     }
 
-    public SimpleSwipeDragCallback(ItemTouchCallback itemTouchCallback, SimpleSwipeCallback.ItemSwipeCallback itemSwipeCallback, int swipeDirs, @ColorInt int bgColor) {
+    public SimpleSwipeDragCallback(ItemTouchCallback itemTouchCallback, SimpleSwipeCallback.ItemSwipeCallback itemSwipeCallback, Drawable leaveBehindDrawable, int swipeDirs, @ColorInt int bgColor) {
         super(itemTouchCallback);
         setDefaultSwipeDirs(swipeDirs);
-        simpleSwipeCallback = new SimpleSwipeCallback(itemSwipeCallback, swipeDirs, bgColor);
+        simpleSwipeCallback = new SimpleSwipeCallback(itemSwipeCallback, leaveBehindDrawable, swipeDirs, bgColor);
     }
 
 

--- a/app/src/main/java/com/mikepenz/fastadapter/app/swipe/SimpleSwipeDragCallback.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/swipe/SimpleSwipeDragCallback.java
@@ -1,5 +1,6 @@
 package com.mikepenz.fastadapter.app.swipe;
 
+import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
@@ -31,6 +32,37 @@ public class SimpleSwipeDragCallback extends SimpleDragCallback {
         simpleSwipeCallback = new SimpleSwipeCallback(itemSwipeCallback, leaveBehindDrawable, swipeDirs, bgColor);
     }
 
+    public SimpleSwipeDragCallback withLeaveBehindSwipeLeft(Drawable d) {
+        setDefaultSwipeDirs(getSwipeDirs(null, null)|ItemTouchHelper.LEFT);
+        simpleSwipeCallback.withLeaveBehindSwipeLeft(d);
+        return this;
+    }
+
+    public SimpleSwipeDragCallback withLeaveBehindSwipeRight(Drawable d) {
+        setDefaultSwipeDirs(getSwipeDirs(null, null) | ItemTouchHelper.RIGHT);
+        simpleSwipeCallback.withLeaveBehindSwipeRight(d);
+        return this;
+    }
+
+    public SimpleSwipeDragCallback withHorizontalMarginDp(Context ctx, int dp) {
+        simpleSwipeCallback.withHorizontalMarginDp(ctx, dp);
+        return this;
+    }
+
+    public SimpleSwipeDragCallback withHorizontalMarginPx(int px) {
+        simpleSwipeCallback.withHorizontalMarginPx(px);
+        return this;
+    }
+
+    public SimpleSwipeDragCallback withBackgroundSwipeLeft(@ColorInt int bgColor) {
+        simpleSwipeCallback.withBackgroundSwipeLeft(bgColor);
+        return this;
+    }
+
+    public SimpleSwipeDragCallback withBackgroundSwipeRight(@ColorInt int bgColor) {
+        simpleSwipeCallback.withBackgroundSwipeRight(bgColor);
+        return this;
+    }
 
     @Override
     public void onSwiped(RecyclerView.ViewHolder viewHolder, int direction) {

--- a/app/src/main/res/layout/swipeable_item.xml
+++ b/app/src/main/res/layout/swipeable_item.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/material_drawer_item_primary">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/swipe_result_content"
+        android:paddingEnd="@dimen/material_drawer_vertical_padding"
+        android:paddingLeft="@dimen/material_drawer_vertical_padding"
+        android:paddingRight="@dimen/material_drawer_vertical_padding"
+        android:paddingStart="@dimen/material_drawer_vertical_padding"
+        android:gravity="center_vertical"
+        android:visibility="visible"
+        android:background="@color/md_red_900">
+
+        <TextView
+            android:id="@+id/swiped_text"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:fontFamily="sans-serif-medium"
+            android:gravity="center_vertical|start"
+            android:lines="1"
+            android:singleLine="true"
+            android:textDirection="anyRtl"
+            android:textColor="@android:color/primary_text_dark"
+            android:textSize="@dimen/material_drawer_item_primary_text"
+            tools:text="Removed" />
+
+        <TextView
+            android:id="@+id/swiped_action"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:fontFamily="sans-serif"
+            android:gravity="center_vertical|start"
+            android:lines="1"
+            android:singleLine="true"
+            android:textDirection="anyRtl"
+            android:textAllCaps="true"
+            android:textColor="@android:color/primary_text_dark"
+            android:textStyle="bold"
+            android:textSize="@dimen/material_drawer_item_primary_description"
+            android:text="@string/action_undo"/>
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/material_drawer_item_primary"
+        android:id="@+id/item_content"
+        android:gravity="center_vertical|start"
+        android:orientation="vertical"
+        android:paddingEnd="@dimen/material_drawer_vertical_padding"
+        android:paddingLeft="@dimen/material_drawer_vertical_padding"
+        android:paddingRight="@dimen/material_drawer_vertical_padding"
+        android:paddingStart="@dimen/material_drawer_vertical_padding"
+        android:elevation="4dp"
+        android:visibility="gone">
+
+        <TextView
+            android:id="@+id/material_drawer_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:fontFamily="sans-serif-medium"
+            android:gravity="center_vertical|start"
+            android:lines="1"
+            android:singleLine="true"
+            android:textDirection="anyRtl"
+            android:textSize="@dimen/material_drawer_item_primary_text"
+            tools:text="Some drawer text" />
+
+        <TextView
+            android:id="@+id/material_drawer_description"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:fontFamily="sans-serif"
+            android:gravity="center_vertical|start"
+            android:lines="1"
+            android:singleLine="true"
+            android:textDirection="anyRtl"
+            android:textSize="@dimen/material_drawer_item_primary_description"
+            tools:text="Some drawer text" />
+    </LinearLayout>
+</FrameLayout>

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -10,4 +10,5 @@
     <item name="fastadapter_right_generic_icon_item_id" type="id" />
 	<item name="fastadapter_checkbox_sample_item_id" type="id" />
 	<item name="fastadapter_radiobutton_sample_item_id" type="id" />
+    <item name="fastadapter_swipable_item_id" type="id"/>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,4 +27,5 @@
     <string name="sample_radiobutton_item_descr">Use FastAdapters internal state with a RadioButton</string>
     <string name="open_source">Open Source</string>
     <string name="search_title">Suche</string>
+    <string name="action_undo">UNDO</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,8 @@
 
     <string name="sample_simple_item_list">SimpleItemList Sample</string>
     <string name="sample_simple_item_list_descr">FastScroller, Filter, Drag&amp;Drop</string>
+    <string name="sample_swipe_list">SwipeList Sample</string>
+    <string name="sample_swipe_list_descr">Swipe, leave-behinds and actions</string>
     <string name="sample_icon_grid">IconGrid Sample</string>
     <string name="sample_icon_grid_descr">Grid, Expandable</string>
     <string name="sample_image_list">ImageList Sample</string>


### PR DESCRIPTION
Swipe remove with in-place undo and "leave-behind" from enhancement issue #43 
This replaces PR #44 which accidently rebased master into the branch.

See discussion in #43 
This adds swipe in two directions to the sample app in a separate activity, while preserving ability to drag (optional). Different swipe directions can be specified with optionally different actions along with icons and background color. Undo of said actions is also possible and included in the example. The undo option is also in place and times out of 3s in the example. A future update could let that stay until scrolled like in the gmail app.

Example app:
![swipe_2](https://cloud.githubusercontent.com/assets/1568245/13078963/100d50a0-d4c2-11e5-8aca-b2b6466e9202.gif)