### PR TITLE
A powerful API for endless scrolling

### DIFF
--- a/library-extensions/src/main/java/android/support/v7/widget/com_mikepenz_fastadapter_extensions_scroll.java
+++ b/library-extensions/src/main/java/android/support/v7/widget/com_mikepenz_fastadapter_extensions_scroll.java
@@ -1,0 +1,21 @@
+package android.support.v7.widget;
+
+import android.support.v7.widget.RecyclerView.LayoutManager;
+
+/**
+ * Why the class name? Because it guarantees zero naming conflicts!
+ * <p>
+ * With this really long name, I recommend `import static *.*` !
+ * <p>
+ * Created by jayson on 3/27/2016.
+ */
+public class com_mikepenz_fastadapter_extensions_scroll {
+
+    public static boolean postOnRecyclerView(LayoutManager layoutManager, Runnable action) {
+        if (layoutManager.mRecyclerView != null) {
+            layoutManager.mRecyclerView.post(action);
+            return true;
+        }
+        return false;
+    }
+}

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessRecyclerOnScrollListener.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessRecyclerOnScrollListener.java
@@ -16,7 +16,7 @@ public abstract class EndlessRecyclerOnScrollListener extends RecyclerView.OnScr
 
     private int mCurrentPage = 1;
 
-    RecyclerView.LayoutManager mLayoutManager;
+    private RecyclerView.LayoutManager mLayoutManager;
 
     public EndlessRecyclerOnScrollListener() {
     }

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessRecyclerOnScrollListener.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessRecyclerOnScrollListener.java
@@ -16,7 +16,7 @@ public abstract class EndlessRecyclerOnScrollListener extends RecyclerView.OnScr
 
     private int mCurrentPage = 1;
 
-    private RecyclerView.LayoutManager mLayoutManager;
+    RecyclerView.LayoutManager mLayoutManager;
 
     public EndlessRecyclerOnScrollListener(RecyclerView.LayoutManager layoutManager) {
         this.mLayoutManager = layoutManager;

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
@@ -1,6 +1,7 @@
 package com.mikepenz.fastadapter_extensions.scroll;
 
 import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.RecyclerView.LayoutManager;
 import android.view.View;
 
@@ -50,6 +51,11 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
 
     public EndlessScrollHelper(LayoutManager layoutManager, int visibleThreshold) {
         super(layoutManager, visibleThreshold);
+    }
+
+    public EndlessScrollHelper<Model> addTo(RecyclerView recyclerView) {
+        recyclerView.addOnScrollListener(this);
+        return this;
     }
 
     /**

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
@@ -45,6 +45,9 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
     private OnLoadMoreHandler<Model> mOnLoadMoreHandler;
     private OnNewItemsListener<Model> mOnNewItemsListener;
 
+    public EndlessScrollHelper() {
+    }
+
     public EndlessScrollHelper(LayoutManager layoutManager) {
         super(layoutManager);
     }
@@ -272,7 +275,7 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
             mResult = result;
             mHelperStrongRef = super.get();
             return mHelperStrongRef != null
-                    && postOnRecyclerView(mHelperStrongRef.mLayoutManager, this);
+                    && postOnRecyclerView(mHelperStrongRef.getLayoutManager(), this);
         }
 
         @Override

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
@@ -155,6 +155,49 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
         return this;
     }
 
+    /**
+     * An overload of {@link #withNewItemsDeliveredTo(IItemAdapter, Function) withNewItemsDeliveredTo()}
+     * that allows additional callbacks.
+     *
+     * @param adapter
+     * @param itemFactory
+     * @param extraOnNewItemsListener
+     * @param <Item>
+     * @return
+     */
+    public <Item extends IItem> EndlessScrollHelper<Model> withNewItemsDeliveredTo(IItemAdapter<Item> adapter, Function<Model, Item> itemFactory, OnNewItemsListener<Model> extraOnNewItemsListener) {
+        if (adapter == null) {
+            throw new NullPointerException("adapter == null");
+        }
+        if (itemFactory == null) {
+            throw new NullPointerException("itemFactory == null");
+        }
+        if (extraOnNewItemsListener == null) {
+            throw new NullPointerException("extraOnNewItemsListener == null");
+        }
+        mOnNewItemsListener = new DeliverToIItemAdapter2<>(adapter, itemFactory, extraOnNewItemsListener);
+        return this;
+    }
+
+    /**
+     * An overload of {@link #withNewItemsDeliveredTo(GenericItemAdapter) withNewItemsDeliveredTo()}
+     * that allows additional callbacks.
+     *
+     * @param adapter
+     * @param extraOnNewItemsListener
+     * @return
+     */
+    public EndlessScrollHelper<Model> withNewItemsDeliveredTo(GenericItemAdapter<Model, ?> adapter, OnNewItemsListener<Model> extraOnNewItemsListener) {
+        if (adapter == null) {
+            throw new NullPointerException("adapter == null");
+        }
+        if (extraOnNewItemsListener == null) {
+            throw new NullPointerException("extraOnNewItemsListener == null");
+        }
+        mOnNewItemsListener = new DeliverToGenericItemAdapter2<>(adapter, extraOnNewItemsListener);
+        return this;
+    }
+
     protected void onLoadMore(ResultReceiver<Model> out, int currentPage) {
         OnLoadMoreHandler<Model> loadMoreHandler = this.mOnLoadMoreHandler;
         try {
@@ -260,6 +303,36 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
         @Override
         public void onNewItems(List<Model> newItems, int page) {
             mGenericItemAdapter.addModel(newItems);
+        }
+    }
+
+    private static class DeliverToIItemAdapter2<Model, Item extends IItem> extends DeliverToIItemAdapter<Model, Item> {
+        private final OnNewItemsListener<Model> mExtraOnNewItemsListener;
+
+        DeliverToIItemAdapter2(IItemAdapter<Item> itemAdapter, Function<Model, Item> itemFactory, OnNewItemsListener<Model> extraOnNewItemsListener) {
+            super(itemAdapter, itemFactory);
+            mExtraOnNewItemsListener = extraOnNewItemsListener;
+        }
+
+        @Override
+        public void onNewItems(List<Model> newItems, int page) {
+            super.onNewItems(newItems, page);
+            mExtraOnNewItemsListener.onNewItems(newItems, page);
+        }
+    }
+
+    private static class DeliverToGenericItemAdapter2<Model, Item extends GenericAbstractItem<Model, Item, ?>> extends DeliverToGenericItemAdapter<Model, Item> {
+        private final OnNewItemsListener<Model> mExtraOnNewItemsListener;
+
+        DeliverToGenericItemAdapter2(GenericItemAdapter<Model, Item> itemAdapter, OnNewItemsListener<Model> extraOnNewItemsListener) {
+            super(itemAdapter);
+            mExtraOnNewItemsListener = extraOnNewItemsListener;
+        }
+
+        @Override
+        public void onNewItems(List<Model> newItems, int page) {
+            super.onNewItems(newItems, page);
+            mExtraOnNewItemsListener.onNewItems(newItems, page);
         }
     }
 }

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
@@ -219,7 +219,7 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
 //                    throw new IllegalStateException("Inconsistent state! "
 //                            + "Page might have already been loaded! "
 //                            + "Or `loadMore(result)` might have been used by more than 1 thread!");
-                    return; // Let it fail and load again
+                    return; // Let it fail and possibly load correctly
                 }
             } catch (NullPointerException npe) {
                 if (mHelperStrongRef == null) {

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
@@ -1,0 +1,214 @@
+package com.mikepenz.fastadapter_extensions.scroll;
+
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.RecyclerView.LayoutManager;
+import android.view.View;
+
+import com.mikepenz.fastadapter.IItem;
+import com.mikepenz.fastadapter.IItemAdapter;
+import com.mikepenz.fastadapter.adapters.GenericItemAdapter;
+import com.mikepenz.fastadapter.items.GenericAbstractItem;
+import com.mikepenz.fastadapter.utils.Function;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+
+import static android.support.v7.widget.com_mikepenz_fastadapter_extensions_scroll.postOnRecyclerView;
+
+/**
+ * This is an extension of {@link EndlessRecyclerOnScrollListener}, providing a more powerful API
+ * for endless scrolling.
+ * <p>
+ * This class exposes 2 callbacks to separate the loading logic from delivering the results:
+ * <ul>
+ * <li>{@link OnLoadMoreHandler OnLoadMoreHandler}</li>
+ * <li>{@link OnNewItemsListener OnNewItemsListener}</li>
+ * </ul>
+ * <p>
+ * This class also takes care of other various stuffs like:
+ * <ul>
+ * <li>Ensuring the results are delivered on the RecyclerView's handler &ndash; which also ensures
+ * that the results are delivered only when the RecyclerView is attached to the window, see {@link
+ * View#post(Runnable)}.</li>
+ * <li>Prevention of memory leaks when implemented properly (i.e. {@link OnLoadMoreHandler
+ * OnLoadMoreHandler} should be implemented via static classes or lambda expressions).</li>
+ * <li>An easier way to deliver results to an {@link #withNewItemsDeliveredTo(IItemAdapter,
+ * Function)  IItemAdapter} or {@link #withNewItemsDeliveredTo(GenericItemAdapter)
+ * GenericItemAdapter}.</li>
+ * </ul>
+ * <p>
+ * Created by jayson on 3/26/2016.
+ */
+public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener {
+    private OnLoadMoreHandler<Model> mOnLoadMoreHandler;
+    private OnNewItemsListener<Model> mOnNewItemsListener;
+
+    public EndlessScrollHelper(LayoutManager layoutManager) {
+        super(layoutManager);
+    }
+
+    public EndlessScrollHelper(LayoutManager layoutManager, int visibleThreshold) {
+        super(layoutManager, visibleThreshold);
+    }
+
+    public interface ResultReceiver<R> {
+
+        int getReceiverPage();
+
+        boolean deliverNewItems(@NonNull List<R> result);
+    }
+
+    public interface OnLoadMoreHandler<R> {
+
+        void onLoadMore(ResultReceiver out, int currentPage);
+    }
+
+    public interface OnNewItemsListener<R> {
+
+        void onNewItems(List<R> newItems, int page);
+    }
+
+    public EndlessScrollHelper<Model> withOnLoadMoreHandler(OnLoadMoreHandler<Model> onLoadMoreHandler) {
+        if (onLoadMoreHandler == null) {
+            throw new NullPointerException("onLoadMoreHandler == null");
+        }
+        mOnLoadMoreHandler = onLoadMoreHandler;
+        return this;
+    }
+
+    public EndlessScrollHelper<Model> withOnNewItemsListener(OnNewItemsListener<Model> onNewItemsListener) {
+        if (onNewItemsListener == null) {
+            throw new NullPointerException("onNewItemsListener == null");
+        }
+        mOnNewItemsListener = onNewItemsListener;
+        return this;
+    }
+
+    public <Item extends IItem> EndlessScrollHelper<Model> withNewItemsDeliveredTo(IItemAdapter<Item> adapter, Function<Model, Item> itemFactory) {
+        if (adapter == null) {
+            throw new NullPointerException("adapter == null");
+        }
+        if (itemFactory == null) {
+            throw new NullPointerException("itemFactory == null");
+        }
+        mOnNewItemsListener = new DeliverToIItemAdapter<>(adapter, itemFactory);
+        return this;
+    }
+
+    public EndlessScrollHelper<Model> withNewItemsDeliveredTo(GenericItemAdapter<Model, ?> adapter) {
+        if (adapter == null) {
+            throw new NullPointerException("adapter == null");
+        }
+        mOnNewItemsListener = new DeliverToGenericItemAdapter<>(adapter);
+        return this;
+    }
+
+    protected void onLoadMore(ResultReceiver out, int currentPage) {
+        OnLoadMoreHandler<Model> loadMoreHandler = this.mOnLoadMoreHandler;
+        try {
+            loadMoreHandler.onLoadMore(out, currentPage);
+        } catch (NullPointerException npe) {
+            // Lazy null checking!
+            if (loadMoreHandler == null) {
+                throw new NullPointerException("You must provide an `OnLoadMoreHandler`");
+            }
+            throw npe;
+        }
+    }
+
+    protected void onNewItems(List<Model> newItems, int page) {
+        OnNewItemsListener<Model> onNewItemsListener = this.mOnNewItemsListener;
+        try {
+            onNewItemsListener.onNewItems(newItems, page);
+        } catch (NullPointerException npe) {
+            // Lazy null checking!
+            if (onNewItemsListener == null) {
+                throw new NullPointerException("You must provide an `OnNewItemsListener`");
+            }
+            throw npe;
+        }
+    }
+
+    @Override
+    public void onLoadMore(int currentPage) {
+        onLoadMore(new ResultReceiverImpl<>(this, currentPage), currentPage);
+    }
+
+    private static final class ResultReceiverImpl<R> extends WeakReference<EndlessScrollHelper<R>> implements ResultReceiver<R>, Runnable {
+        private final int mReceiverPage;
+        private EndlessScrollHelper<R> mHelperStrongRef;
+        private List<R> mResult;
+
+        ResultReceiverImpl(EndlessScrollHelper<R> helper, int receiverPage) {
+            super(helper); // We use WeakReferences to outer class to avoid memory leaks.
+            mReceiverPage = receiverPage;
+        }
+
+        @Override
+        public int getReceiverPage() {
+            return mReceiverPage;
+        }
+
+        @Override
+        public boolean deliverNewItems(@NonNull List<R> result) {
+            if (mResult != null) // We might also see `null` here if more than 1 thread is modifying this.
+                throw new IllegalStateException("`result` already provided!");
+            mResult = result;
+            mHelperStrongRef = super.get();
+            return mHelperStrongRef != null
+                    && postOnRecyclerView(mHelperStrongRef.mLayoutManager, this);
+        }
+
+        @Override
+        public void run() {
+            // At this point, mHelperStrongRef != null
+            try {
+                if (mHelperStrongRef.getCurrentPage() != mReceiverPage) {
+                    throw new IllegalStateException("Inconsistent state! "
+                            + "Page might have already been loaded! "
+                            + "Or `loadMore(result)` might have been used by more than 1 thread!");
+                }
+            } catch (NullPointerException npe) {
+                if (mHelperStrongRef == null) {
+                    throw new AssertionError(npe);
+                }
+                throw npe;
+            }
+            mHelperStrongRef.onNewItems(mResult, mReceiverPage);
+        }
+    }
+
+    private static class DeliverToIItemAdapter<Model, Item extends IItem> implements OnNewItemsListener<Model> {
+        private final IItemAdapter<Item> mItemAdapter;
+        private final Function<Model, Item> mItemFactory;
+
+        DeliverToIItemAdapter(IItemAdapter<Item> itemAdapter, Function<Model, Item> itemFactory) {
+            mItemAdapter = itemAdapter;
+            mItemFactory = itemFactory;
+        }
+
+        @Override
+        public void onNewItems(List<Model> newItems, int page) {
+            List<Item> iitems = new ArrayList<>(newItems.size());
+            for (Model model : newItems) {
+                iitems.add(mItemFactory.apply(model));
+            }
+            mItemAdapter.add(iitems);
+        }
+    }
+
+    private static class DeliverToGenericItemAdapter<Model, Item extends GenericAbstractItem<Model, Item, ?>> implements OnNewItemsListener<Model> {
+        private final GenericItemAdapter<Model, Item> mGenericItemAdapter;
+
+        DeliverToGenericItemAdapter(GenericItemAdapter<Model, Item> itemAdapter) {
+            mGenericItemAdapter = itemAdapter;
+        }
+
+        @Override
+        public void onNewItems(List<Model> newItems, int page) {
+            mGenericItemAdapter.addModel(newItems);
+        }
+    }
+}

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
@@ -1,7 +1,6 @@
 package com.mikepenz.fastadapter_extensions.scroll;
 
 import android.support.annotation.NonNull;
-import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.RecyclerView.LayoutManager;
 import android.view.View;
 
@@ -53,21 +52,21 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
         super(layoutManager, visibleThreshold);
     }
 
-    public interface ResultReceiver<R> {
+    public interface ResultReceiver<Model> {
 
         int getReceiverPage();
 
-        boolean deliverNewItems(@NonNull List<R> result);
+        boolean deliverNewItems(@NonNull List<Model> result);
     }
 
-    public interface OnLoadMoreHandler<R> {
+    public interface OnLoadMoreHandler<Model> {
 
-        void onLoadMore(ResultReceiver out, int currentPage);
+        void onLoadMore(ResultReceiver<Model> out, int currentPage);
     }
 
-    public interface OnNewItemsListener<R> {
+    public interface OnNewItemsListener<Model> {
 
-        void onNewItems(List<R> newItems, int page);
+        void onNewItems(List<Model> newItems, int page);
     }
 
     public EndlessScrollHelper<Model> withOnLoadMoreHandler(OnLoadMoreHandler<Model> onLoadMoreHandler) {
@@ -105,7 +104,7 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
         return this;
     }
 
-    protected void onLoadMore(ResultReceiver out, int currentPage) {
+    protected void onLoadMore(ResultReceiver<Model> out, int currentPage) {
         OnLoadMoreHandler<Model> loadMoreHandler = this.mOnLoadMoreHandler;
         try {
             loadMoreHandler.onLoadMore(out, currentPage);
@@ -136,12 +135,12 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
         onLoadMore(new ResultReceiverImpl<>(this, currentPage), currentPage);
     }
 
-    private static final class ResultReceiverImpl<R> extends WeakReference<EndlessScrollHelper<R>> implements ResultReceiver<R>, Runnable {
+    private static final class ResultReceiverImpl<Model> extends WeakReference<EndlessScrollHelper<Model>> implements ResultReceiver<Model>, Runnable {
         private final int mReceiverPage;
-        private EndlessScrollHelper<R> mHelperStrongRef;
-        private List<R> mResult;
+        private EndlessScrollHelper<Model> mHelperStrongRef;
+        private List<Model> mResult;
 
-        ResultReceiverImpl(EndlessScrollHelper<R> helper, int receiverPage) {
+        ResultReceiverImpl(EndlessScrollHelper<Model> helper, int receiverPage) {
             super(helper); // We use WeakReferences to outer class to avoid memory leaks.
             mReceiverPage = receiverPage;
         }
@@ -152,7 +151,7 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
         }
 
         @Override
-        public boolean deliverNewItems(@NonNull List<R> result) {
+        public boolean deliverNewItems(@NonNull List<Model> result) {
             if (mResult != null) // We might also see `null` here if more than 1 thread is modifying this.
                 throw new IllegalStateException("`result` already provided!");
             mResult = result;

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
@@ -346,8 +346,8 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
 
         @Override
         public void onNewItems(@NonNull List<Model> newItems, int page) {
-            super.onNewItems(newItems, page);
             mExtraOnNewItemsListener.onNewItems(newItems, page);
+            super.onNewItems(newItems, page);
         }
     }
 
@@ -361,8 +361,8 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
 
         @Override
         public void onNewItems(@NonNull List<Model> newItems, int page) {
-            super.onNewItems(newItems, page);
             mExtraOnNewItemsListener.onNewItems(newItems, page);
+            super.onNewItems(newItems, page);
         }
     }
 }

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
@@ -88,7 +88,7 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
          * @param out
          * @param currentPage
          */
-        void onLoadMore(ResultReceiver<Model> out, int currentPage);
+        void onLoadMore(@NonNull ResultReceiver<Model> out, int currentPage);
     }
 
     public interface OnNewItemsListener<Model> {
@@ -100,21 +100,15 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
          * @param newItems
          * @param page
          */
-        void onNewItems(List<Model> newItems, int page);
+        void onNewItems(@NonNull List<Model> newItems, int page);
     }
 
-    public EndlessScrollHelper<Model> withOnLoadMoreHandler(OnLoadMoreHandler<Model> onLoadMoreHandler) {
-        if (onLoadMoreHandler == null) {
-            throw new NullPointerException("onLoadMoreHandler == null");
-        }
+    public EndlessScrollHelper<Model> withOnLoadMoreHandler(@NonNull OnLoadMoreHandler<Model> onLoadMoreHandler) {
         mOnLoadMoreHandler = onLoadMoreHandler;
         return this;
     }
 
-    public EndlessScrollHelper<Model> withOnNewItemsListener(OnNewItemsListener<Model> onNewItemsListener) {
-        if (onNewItemsListener == null) {
-            throw new NullPointerException("onNewItemsListener == null");
-        }
+    public EndlessScrollHelper<Model> withOnNewItemsListener(@NonNull OnNewItemsListener<Model> onNewItemsListener) {
         mOnNewItemsListener = onNewItemsListener;
         return this;
     }
@@ -129,13 +123,7 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
      * @param <Item>
      * @return
      */
-    public <Item extends IItem> EndlessScrollHelper<Model> withNewItemsDeliveredTo(IItemAdapter<Item> adapter, Function<Model, Item> itemFactory) {
-        if (adapter == null) {
-            throw new NullPointerException("adapter == null");
-        }
-        if (itemFactory == null) {
-            throw new NullPointerException("itemFactory == null");
-        }
+    public <Item extends IItem> EndlessScrollHelper<Model> withNewItemsDeliveredTo(@NonNull IItemAdapter<Item> adapter, @NonNull Function<Model, Item> itemFactory) {
         mOnNewItemsListener = new DeliverToIItemAdapter<>(adapter, itemFactory);
         return this;
     }
@@ -147,10 +135,7 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
      * @param adapter
      * @return
      */
-    public EndlessScrollHelper<Model> withNewItemsDeliveredTo(GenericItemAdapter<Model, ?> adapter) {
-        if (adapter == null) {
-            throw new NullPointerException("adapter == null");
-        }
+    public EndlessScrollHelper<Model> withNewItemsDeliveredTo(@NonNull GenericItemAdapter<Model, ?> adapter) {
         mOnNewItemsListener = new DeliverToGenericItemAdapter<>(adapter);
         return this;
     }
@@ -165,16 +150,7 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
      * @param <Item>
      * @return
      */
-    public <Item extends IItem> EndlessScrollHelper<Model> withNewItemsDeliveredTo(IItemAdapter<Item> adapter, Function<Model, Item> itemFactory, OnNewItemsListener<Model> extraOnNewItemsListener) {
-        if (adapter == null) {
-            throw new NullPointerException("adapter == null");
-        }
-        if (itemFactory == null) {
-            throw new NullPointerException("itemFactory == null");
-        }
-        if (extraOnNewItemsListener == null) {
-            throw new NullPointerException("extraOnNewItemsListener == null");
-        }
+    public <Item extends IItem> EndlessScrollHelper<Model> withNewItemsDeliveredTo(@NonNull IItemAdapter<Item> adapter, @NonNull Function<Model, Item> itemFactory, @NonNull OnNewItemsListener<Model> extraOnNewItemsListener) {
         mOnNewItemsListener = new DeliverToIItemAdapter2<>(adapter, itemFactory, extraOnNewItemsListener);
         return this;
     }
@@ -187,18 +163,12 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
      * @param extraOnNewItemsListener
      * @return
      */
-    public EndlessScrollHelper<Model> withNewItemsDeliveredTo(GenericItemAdapter<Model, ?> adapter, OnNewItemsListener<Model> extraOnNewItemsListener) {
-        if (adapter == null) {
-            throw new NullPointerException("adapter == null");
-        }
-        if (extraOnNewItemsListener == null) {
-            throw new NullPointerException("extraOnNewItemsListener == null");
-        }
+    public EndlessScrollHelper<Model> withNewItemsDeliveredTo(@NonNull GenericItemAdapter<Model, ?> adapter, @NonNull OnNewItemsListener<Model> extraOnNewItemsListener) {
         mOnNewItemsListener = new DeliverToGenericItemAdapter2<>(adapter, extraOnNewItemsListener);
         return this;
     }
 
-    protected void onLoadMore(ResultReceiver<Model> out, int currentPage) {
+    protected void onLoadMore(@NonNull ResultReceiver<Model> out, int currentPage) {
         OnLoadMoreHandler<Model> loadMoreHandler = this.mOnLoadMoreHandler;
         try {
             loadMoreHandler.onLoadMore(out, currentPage);
@@ -211,7 +181,7 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
         }
     }
 
-    protected void onNewItems(List<Model> newItems, int page) {
+    protected void onNewItems(@NonNull List<Model> newItems, int page) {
         OnNewItemsListener<Model> onNewItemsListener = this.mOnNewItemsListener;
         try {
             onNewItemsListener.onNewItems(newItems, page);
@@ -275,16 +245,16 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
     }
 
     private static class DeliverToIItemAdapter<Model, Item extends IItem> implements OnNewItemsListener<Model> {
-        private final IItemAdapter<Item> mItemAdapter;
-        private final Function<Model, Item> mItemFactory;
+        @NonNull private final IItemAdapter<Item> mItemAdapter;
+        @NonNull private final Function<Model, Item> mItemFactory;
 
-        DeliverToIItemAdapter(IItemAdapter<Item> itemAdapter, Function<Model, Item> itemFactory) {
+        DeliverToIItemAdapter(@NonNull IItemAdapter<Item> itemAdapter, @NonNull Function<Model, Item> itemFactory) {
             mItemAdapter = itemAdapter;
             mItemFactory = itemFactory;
         }
 
         @Override
-        public void onNewItems(List<Model> newItems, int page) {
+        public void onNewItems(@NonNull List<Model> newItems, int page) {
             List<Item> iitems = new ArrayList<>(newItems.size());
             for (Model model : newItems) {
                 iitems.add(mItemFactory.apply(model));
@@ -294,43 +264,43 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
     }
 
     private static class DeliverToGenericItemAdapter<Model, Item extends GenericAbstractItem<Model, Item, ?>> implements OnNewItemsListener<Model> {
-        private final GenericItemAdapter<Model, Item> mGenericItemAdapter;
+        @NonNull private final GenericItemAdapter<Model, Item> mGenericItemAdapter;
 
-        DeliverToGenericItemAdapter(GenericItemAdapter<Model, Item> itemAdapter) {
+        DeliverToGenericItemAdapter(@NonNull GenericItemAdapter<Model, Item> itemAdapter) {
             mGenericItemAdapter = itemAdapter;
         }
 
         @Override
-        public void onNewItems(List<Model> newItems, int page) {
+        public void onNewItems(@NonNull List<Model> newItems, int page) {
             mGenericItemAdapter.addModel(newItems);
         }
     }
 
     private static class DeliverToIItemAdapter2<Model, Item extends IItem> extends DeliverToIItemAdapter<Model, Item> {
-        private final OnNewItemsListener<Model> mExtraOnNewItemsListener;
+        @NonNull private final OnNewItemsListener<Model> mExtraOnNewItemsListener;
 
-        DeliverToIItemAdapter2(IItemAdapter<Item> itemAdapter, Function<Model, Item> itemFactory, OnNewItemsListener<Model> extraOnNewItemsListener) {
+        DeliverToIItemAdapter2(@NonNull IItemAdapter<Item> itemAdapter, @NonNull Function<Model, Item> itemFactory, @NonNull OnNewItemsListener<Model> extraOnNewItemsListener) {
             super(itemAdapter, itemFactory);
             mExtraOnNewItemsListener = extraOnNewItemsListener;
         }
 
         @Override
-        public void onNewItems(List<Model> newItems, int page) {
+        public void onNewItems(@NonNull List<Model> newItems, int page) {
             super.onNewItems(newItems, page);
             mExtraOnNewItemsListener.onNewItems(newItems, page);
         }
     }
 
     private static class DeliverToGenericItemAdapter2<Model, Item extends GenericAbstractItem<Model, Item, ?>> extends DeliverToGenericItemAdapter<Model, Item> {
-        private final OnNewItemsListener<Model> mExtraOnNewItemsListener;
+        @NonNull private final OnNewItemsListener<Model> mExtraOnNewItemsListener;
 
-        DeliverToGenericItemAdapter2(GenericItemAdapter<Model, Item> itemAdapter, OnNewItemsListener<Model> extraOnNewItemsListener) {
+        DeliverToGenericItemAdapter2(@NonNull GenericItemAdapter<Model, Item> itemAdapter, @NonNull OnNewItemsListener<Model> extraOnNewItemsListener) {
             super(itemAdapter);
             mExtraOnNewItemsListener = extraOnNewItemsListener;
         }
 
         @Override
-        public void onNewItems(List<Model> newItems, int page) {
+        public void onNewItems(@NonNull List<Model> newItems, int page) {
             super.onNewItems(newItems, page);
             mExtraOnNewItemsListener.onNewItems(newItems, page);
         }

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
@@ -168,6 +168,12 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
         return this;
     }
 
+    //-------------------------
+    //-------------------------
+    //Override-able methods
+    //-------------------------
+    //-------------------------
+
     protected void onLoadMore(@NonNull ResultReceiver<Model> out, int currentPage) {
         OnLoadMoreHandler<Model> loadMoreHandler = this.mOnLoadMoreHandler;
         try {
@@ -193,6 +199,12 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
             throw npe;
         }
     }
+
+    //-------------------------
+    //-------------------------
+    //Internal stuff
+    //-------------------------
+    //-------------------------
 
     @Override
     public void onLoadMore(int currentPage) {
@@ -243,6 +255,12 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
             mHelperStrongRef.onNewItems(mResult, mReceiverPage);
         }
     }
+
+    //-----------------------------------------
+    //-----------------------------------------
+    //`withNewItemsDeliveredTo()` stuff
+    //-----------------------------------------
+    //-----------------------------------------
 
     private static class DeliverToIItemAdapter<Model, Item extends IItem> implements OnNewItemsListener<Model> {
         @NonNull private final IItemAdapter<Item> mItemAdapter;

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
@@ -118,13 +118,13 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
      * specified {@link IItemAdapter}. Converting each result to an {@link IItem} using the given
      * {@code itemFactory}.
      *
-     * @param adapter
+     * @param itemAdapter
      * @param itemFactory
      * @param <Item>
      * @return
      */
-    public <Item extends IItem> EndlessScrollHelper<Model> withNewItemsDeliveredTo(@NonNull IItemAdapter<Item> adapter, @NonNull Function<Model, Item> itemFactory) {
-        mOnNewItemsListener = new DeliverToIItemAdapter<>(adapter, itemFactory);
+    public <Item extends IItem> EndlessScrollHelper<Model> withNewItemsDeliveredTo(@NonNull IItemAdapter<Item> itemAdapter, @NonNull Function<Model, Item> itemFactory) {
+        mOnNewItemsListener = new DeliverToIItemAdapter<>(itemAdapter, itemFactory);
         return this;
     }
 
@@ -132,11 +132,11 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
      * Registers an {@link OnNewItemsListener OnNewItemsListener} that delivers results to the
      * specified {@link GenericItemAdapter} through its {@link GenericItemAdapter#addModel} method.
      *
-     * @param adapter
+     * @param genericItemAdapter
      * @return
      */
-    public EndlessScrollHelper<Model> withNewItemsDeliveredTo(@NonNull GenericItemAdapter<Model, ?> adapter) {
-        mOnNewItemsListener = new DeliverToGenericItemAdapter<>(adapter);
+    public EndlessScrollHelper<Model> withNewItemsDeliveredTo(@NonNull GenericItemAdapter<Model, ?> genericItemAdapter) {
+        mOnNewItemsListener = new DeliverToGenericItemAdapter<>(genericItemAdapter);
         return this;
     }
 
@@ -144,14 +144,14 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
      * An overload of {@link #withNewItemsDeliveredTo(IItemAdapter, Function) withNewItemsDeliveredTo()}
      * that allows additional callbacks.
      *
-     * @param adapter
+     * @param itemAdapter
      * @param itemFactory
      * @param extraOnNewItemsListener
      * @param <Item>
      * @return
      */
-    public <Item extends IItem> EndlessScrollHelper<Model> withNewItemsDeliveredTo(@NonNull IItemAdapter<Item> adapter, @NonNull Function<Model, Item> itemFactory, @NonNull OnNewItemsListener<Model> extraOnNewItemsListener) {
-        mOnNewItemsListener = new DeliverToIItemAdapter2<>(adapter, itemFactory, extraOnNewItemsListener);
+    public <Item extends IItem> EndlessScrollHelper<Model> withNewItemsDeliveredTo(@NonNull IItemAdapter<Item> itemAdapter, @NonNull Function<Model, Item> itemFactory, @NonNull OnNewItemsListener<Model> extraOnNewItemsListener) {
+        mOnNewItemsListener = new DeliverToIItemAdapter2<>(itemAdapter, itemFactory, extraOnNewItemsListener);
         return this;
     }
 
@@ -159,12 +159,12 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
      * An overload of {@link #withNewItemsDeliveredTo(GenericItemAdapter) withNewItemsDeliveredTo()}
      * that allows additional callbacks.
      *
-     * @param adapter
+     * @param genericItemAdapter
      * @param extraOnNewItemsListener
      * @return
      */
-    public EndlessScrollHelper<Model> withNewItemsDeliveredTo(@NonNull GenericItemAdapter<Model, ?> adapter, @NonNull OnNewItemsListener<Model> extraOnNewItemsListener) {
-        mOnNewItemsListener = new DeliverToGenericItemAdapter2<>(adapter, extraOnNewItemsListener);
+    public EndlessScrollHelper<Model> withNewItemsDeliveredTo(@NonNull GenericItemAdapter<Model, ?> genericItemAdapter, @NonNull OnNewItemsListener<Model> extraOnNewItemsListener) {
+        mOnNewItemsListener = new DeliverToGenericItemAdapter2<>(genericItemAdapter, extraOnNewItemsListener);
         return this;
     }
 
@@ -284,8 +284,8 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
     private static class DeliverToGenericItemAdapter<Model, Item extends GenericAbstractItem<Model, Item, ?>> implements OnNewItemsListener<Model> {
         @NonNull private final GenericItemAdapter<Model, Item> mGenericItemAdapter;
 
-        DeliverToGenericItemAdapter(@NonNull GenericItemAdapter<Model, Item> itemAdapter) {
-            mGenericItemAdapter = itemAdapter;
+        DeliverToGenericItemAdapter(@NonNull GenericItemAdapter<Model, Item> genericItemAdapter) {
+            mGenericItemAdapter = genericItemAdapter;
         }
 
         @Override
@@ -312,8 +312,8 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
     private static class DeliverToGenericItemAdapter2<Model, Item extends GenericAbstractItem<Model, Item, ?>> extends DeliverToGenericItemAdapter<Model, Item> {
         @NonNull private final OnNewItemsListener<Model> mExtraOnNewItemsListener;
 
-        DeliverToGenericItemAdapter2(@NonNull GenericItemAdapter<Model, Item> itemAdapter, @NonNull OnNewItemsListener<Model> extraOnNewItemsListener) {
-            super(itemAdapter);
+        DeliverToGenericItemAdapter2(@NonNull GenericItemAdapter<Model, Item> genericItemAdapter, @NonNull OnNewItemsListener<Model> extraOnNewItemsListener) {
+            super(genericItemAdapter);
             mExtraOnNewItemsListener = extraOnNewItemsListener;
         }
 

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
@@ -216,9 +216,10 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
             // At this point, mHelperStrongRef != null
             try {
                 if (mHelperStrongRef.getCurrentPage() != mReceiverPage) {
-                    throw new IllegalStateException("Inconsistent state! "
-                            + "Page might have already been loaded! "
-                            + "Or `loadMore(result)` might have been used by more than 1 thread!");
+//                    throw new IllegalStateException("Inconsistent state! "
+//                            + "Page might have already been loaded! "
+//                            + "Or `loadMore(result)` might have been used by more than 1 thread!");
+                    return; // Let it fail and load again
                 }
             } catch (NullPointerException npe) {
                 if (mHelperStrongRef == null) {

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
@@ -205,11 +205,9 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
         try {
             loadMoreHandler.onLoadMore(out, currentPage);
         } catch (NullPointerException npe) {
-            // Lazy null checking!
-            if (loadMoreHandler == null) {
-                throw new NullPointerException("You must provide an `OnLoadMoreHandler`");
-            }
-            throw npe;
+            // Lazy null checking! If this was our npe, then throw with an appropriate message.
+            throw loadMoreHandler != null ? npe
+                    : new NullPointerException("You must provide an `OnLoadMoreHandler`");
         }
     }
 
@@ -226,11 +224,9 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
         try {
             onNewItemsListener.onNewItems(newItems, page);
         } catch (NullPointerException npe) {
-            // Lazy null checking!
-            if (onNewItemsListener == null) {
-                throw new NullPointerException("You must provide an `OnNewItemsListener`");
-            }
-            throw npe;
+            // Lazy null checking! If this was our npe, then throw with an appropriate message.
+            throw onNewItemsListener != null ? npe
+                    : new NullPointerException("You must provide an `OnNewItemsListener`");
         }
     }
 

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
@@ -19,13 +19,13 @@ import static android.support.v7.widget.com_mikepenz_fastadapter_extensions_scro
 /**
  * This is an extension of {@link EndlessRecyclerOnScrollListener}, providing a more powerful API
  * for endless scrolling.
- * <p>
+ * <p/>
  * This class exposes 2 callbacks to separate the loading logic from delivering the results:
  * <ul>
  * <li>{@link OnLoadMoreHandler OnLoadMoreHandler}</li>
  * <li>{@link OnNewItemsListener OnNewItemsListener}</li>
  * </ul>
- * <p>
+ * <p/>
  * This class also takes care of other various stuffs like:
  * <ul>
  * <li>Ensuring the results are delivered on the RecyclerView's handler &ndash; which also ensures
@@ -37,7 +37,7 @@ import static android.support.v7.widget.com_mikepenz_fastadapter_extensions_scro
  * Function)  IItemAdapter} or {@link #withNewItemsDeliveredTo(GenericItemAdapter)
  * GenericItemAdapter}.</li>
  * </ul>
- * <p>
+ * <p/>
  * Created by jayson on 3/26/2016.
  */
 public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener {
@@ -52,20 +52,54 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
         super(layoutManager, visibleThreshold);
     }
 
+    /**
+     * A callback interface provided by the {@link EndlessScrollHelper} where
+     * {@link #onLoadMore(ResultReceiver, int) onLoadMore()} results are to be delivered.
+     * The underlying implementation is thread-safe as long as only 1 thread is using it.
+     *
+     * @param <Model>
+     */
     public interface ResultReceiver<Model> {
 
+        /**
+         * @return the current page where the results will be delivered.
+         */
         int getReceiverPage();
 
+        /**
+         * Delivers the result of an {@link #onLoadMore(ResultReceiver, int) onLoadMore()} for the
+         * current {@linkplain #getReceiverPage() page}. This method must be called only once.
+         *
+         * @param result the result of an {@link #onLoadMore(ResultReceiver, int) onLoadMore()}
+         * @return whether results where delivered successfully or not, possibly because the
+         * RecyclerView is no longer attached or the {@link EndlessScrollHelper} is no longer
+         * in use (and it has been garbage collected).
+         * @throws IllegalStateException when more than one results are delivered.
+         */
         boolean deliverNewItems(@NonNull List<Model> result);
     }
 
     public interface OnLoadMoreHandler<Model> {
 
+        /**
+         * Handles loading of the specified page and delivers the results to the specified
+         * {@link ResultReceiver}.
+         *
+         * @param out
+         * @param currentPage
+         */
         void onLoadMore(ResultReceiver<Model> out, int currentPage);
     }
 
     public interface OnNewItemsListener<Model> {
 
+        /**
+         * Called on the RecyclerView's message queue to receive the results of a previous
+         * {@link #onLoadMore(ResultReceiver, int) onLoadMore()}.
+         *
+         * @param newItems
+         * @param page
+         */
         void onNewItems(List<Model> newItems, int page);
     }
 
@@ -85,6 +119,16 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
         return this;
     }
 
+    /**
+     * Registers an {@link OnNewItemsListener OnNewItemsListener} that delivers results to the
+     * specified {@link IItemAdapter}. Converting each result to an {@link IItem} using the given
+     * {@code itemFactory}.
+     *
+     * @param adapter
+     * @param itemFactory
+     * @param <Item>
+     * @return
+     */
     public <Item extends IItem> EndlessScrollHelper<Model> withNewItemsDeliveredTo(IItemAdapter<Item> adapter, Function<Model, Item> itemFactory) {
         if (adapter == null) {
             throw new NullPointerException("adapter == null");
@@ -96,6 +140,13 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
         return this;
     }
 
+    /**
+     * Registers an {@link OnNewItemsListener OnNewItemsListener} that delivers results to the
+     * specified {@link GenericItemAdapter} through its {@link GenericItemAdapter#addModel} method.
+     *
+     * @param adapter
+     * @return
+     */
     public EndlessScrollHelper<Model> withNewItemsDeliveredTo(GenericItemAdapter<Model, ?> adapter) {
         if (adapter == null) {
             throw new NullPointerException("adapter == null");

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
@@ -61,7 +61,10 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
     /**
      * A callback interface provided by the {@link EndlessScrollHelper} where
      * {@link #onLoadMore(ResultReceiver, int) onLoadMore()} results are to be delivered.
-     * The underlying implementation is thread-safe as long as only 1 thread is using it.
+     * <p/>
+     * The underlying implementation is safe to use by any background-thread, as long as only 1
+     * thread is using it. Results delivered via {@link #deliverNewItems(List)} are automatically
+     * dispatched to the RecyclerView's message queue (i.e. to be delivered in the ui thread).
      *
      * @param <Model>
      */

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessScrollHelper.java
@@ -103,11 +103,27 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
         void onNewItems(@NonNull List<Model> newItems, int page);
     }
 
+    /**
+     * Define the {@link OnLoadMoreHandler OnLoadMoreHandler} which will be used for loading new
+     * items.
+     *
+     * @param onLoadMoreHandler
+     * @return
+     */
     public EndlessScrollHelper<Model> withOnLoadMoreHandler(@NonNull OnLoadMoreHandler<Model> onLoadMoreHandler) {
         mOnLoadMoreHandler = onLoadMoreHandler;
         return this;
     }
 
+    /**
+     * Define the {@link OnNewItemsListener OnNewItemsListener} which will receive the new items
+     * loaded by {@link #onLoadMore(ResultReceiver, int) onLoadMore()}.
+     *
+     * @param onNewItemsListener
+     * @return
+     * @see #withNewItemsDeliveredTo(IItemAdapter, Function) withNewItemsDeliveredTo(IItemAdapter, Function)
+     * @see #withNewItemsDeliveredTo(GenericItemAdapter) withNewItemsDeliveredTo(GenericItemAdapter)
+     */
     public EndlessScrollHelper<Model> withOnNewItemsListener(@NonNull OnNewItemsListener<Model> onNewItemsListener) {
         mOnNewItemsListener = onNewItemsListener;
         return this;
@@ -122,6 +138,7 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
      * @param itemFactory
      * @param <Item>
      * @return
+     * @see #withNewItemsDeliveredTo(IItemAdapter, Function, OnNewItemsListener) withNewItemsDeliveredTo(IItemAdapter, Function, OnNewItemsListener)
      */
     public <Item extends IItem> EndlessScrollHelper<Model> withNewItemsDeliveredTo(@NonNull IItemAdapter<Item> itemAdapter, @NonNull Function<Model, Item> itemFactory) {
         mOnNewItemsListener = new DeliverToIItemAdapter<>(itemAdapter, itemFactory);
@@ -134,6 +151,7 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
      *
      * @param genericItemAdapter
      * @return
+     * @see #withNewItemsDeliveredTo(GenericItemAdapter, OnNewItemsListener) withNewItemsDeliveredTo(GenericItemAdapter, OnNewItemsListener)
      */
     public EndlessScrollHelper<Model> withNewItemsDeliveredTo(@NonNull GenericItemAdapter<Model, ?> genericItemAdapter) {
         mOnNewItemsListener = new DeliverToGenericItemAdapter<>(genericItemAdapter);
@@ -174,6 +192,14 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
     //-------------------------
     //-------------------------
 
+    /**
+     * The default implementation takes care of calling the previously set
+     * {@link OnLoadMoreHandler OnLoadMoreHandler}.
+     *
+     * @param out
+     * @param currentPage
+     * @see #withOnLoadMoreHandler(OnLoadMoreHandler) withOnLoadMoreHandler(OnLoadMoreHandler)
+     */
     protected void onLoadMore(@NonNull ResultReceiver<Model> out, int currentPage) {
         OnLoadMoreHandler<Model> loadMoreHandler = this.mOnLoadMoreHandler;
         try {
@@ -187,6 +213,14 @@ public class EndlessScrollHelper<Model> extends EndlessRecyclerOnScrollListener 
         }
     }
 
+    /**
+     * The default implementation takes care of calling the previously set
+     * {@link OnNewItemsListener OnNewItemsListener}.
+     *
+     * @param newItems
+     * @param page
+     * @see #withOnNewItemsListener(OnNewItemsListener) withOnNewItemsListener(OnNewItemsListener)
+     */
     protected void onNewItems(@NonNull List<Model> newItems, int page) {
         OnNewItemsListener<Model> onNewItemsListener = this.mOnNewItemsListener;
         try {


### PR DESCRIPTION
I would like to add `EndlessScrollHelper`
- An extension of `EndlessRecyclerOnScrollListener` that allows a more granular implementation of `onLoadMore()`.
- Providing an easy construct for running an asynchronous loader to load the new items and automatically handling the delivery of those stuff to the main thread.

It also comes with a utility that delivers the new items to an `IItemAdapter` or `GenericItemAdapter`.

I'm not sure if I'm convinced with the naming so feel free to criticize! ;)