### PR TITLE
ActionModeHelper improved

### DIFF
--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/ActionModeHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/ActionModeHelper.java
@@ -146,7 +146,7 @@ public class ActionModeHelper {
             if (mTitleProvider != null)
                 mActionMode.setTitle(mTitleProvider.getTitle(selected));
             else
-                mActionMode.setTitle(selected);
+                mActionMode.setTitle(String.valueOf(selected));
         }
     }
 

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/ActionModeHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/ActionModeHelper.java
@@ -25,7 +25,7 @@ public class ActionModeHelper {
 
     private boolean mAutoDeselect = true;
 
-    private ActionModeTitleProvider mTitleProvider = null;
+    private ActionModeTitleProvider mTitleProvider;
 
     public ActionModeHelper(FastAdapter fastAdapter, int cabMenu) {
         this.mFastAdapter = fastAdapter;
@@ -89,8 +89,7 @@ public class ActionModeHelper {
             return false;
         }
 
-        if (mActionMode != null)
-        {
+        if (mActionMode != null) {
             // calculate the selection count for the action mode
             // because current selection is not reflecting the future state yet!
             int selected = mFastAdapter.getSelections().size();
@@ -144,11 +143,9 @@ public class ActionModeHelper {
                 mActionMode = null;
             }
         }
-        else {
-            if (mActionMode == null) {
-                if (act != null) // without an activity, we cannot start the action mode
-                    mActionMode = act.startSupportActionMode(mInternalCallback);
-            }
+        else if (mActionMode == null) {
+            if (act != null) // without an activity, we cannot start the action mode
+                mActionMode = act.startSupportActionMode(mInternalCallback);
         }
         updateTitle(selected);
         return mActionMode;
@@ -160,8 +157,7 @@ public class ActionModeHelper {
      * @param selected      number of selected items
      */
     private void updateTitle(int selected) {
-        if (mActionMode != null)
-        {
+        if (mActionMode != null) {
             if (mTitleProvider != null)
                 mActionMode.setTitle(mTitleProvider.getTitle(selected));
             else

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/ActionModeHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/ActionModeHelper.java
@@ -23,6 +23,8 @@ public class ActionModeHelper {
     private ActionMode.Callback mCallback;
     private ActionMode mActionMode;
 
+    private boolean mAutoDeselect = true;
+
     private ActionModeTitleProvider mTitleProvider = null;
 
     public ActionModeHelper(FastAdapter fastAdapter, int cabMenu) {
@@ -43,6 +45,11 @@ public class ActionModeHelper {
         return this;
     }
 
+    public ActionModeHelper withAutoDeselect(boolean enabled) {
+        this.mAutoDeselect = enabled;
+        return this;
+    }
+
     public ActionMode getActionMode() {
         return mActionMode;
     }
@@ -54,6 +61,17 @@ public class ActionModeHelper {
      */
     public boolean isActive() {
         return mActionMode != null;
+    }
+
+    /**
+     * implements the basic behavior of a CAB and multi select behavior,
+     * including logics if the clicked item is collapsible
+     *
+     * @param item the current item
+     * @return null if nothing was done, or a boolean to inform if the event was consumed
+     */
+    public Boolean onClick(IItem item) {
+        return onClick(null, item);
     }
 
     /**
@@ -128,7 +146,8 @@ public class ActionModeHelper {
         }
         else {
             if (mActionMode == null) {
-                mActionMode = act.startSupportActionMode(mInternalCallback);
+                if (act != null) // without an activity, we cannot start the action mode
+                    mActionMode = act.startSupportActionMode(mInternalCallback);
             }
         }
         updateTitle(selected);
@@ -140,7 +159,7 @@ public class ActionModeHelper {
      *
      * @param selected      number of selected items
      */
-    private void updateTitle(Integer selected) {
+    private void updateTitle(int selected) {
         if (mActionMode != null)
         {
             if (mTitleProvider != null)
@@ -188,7 +207,8 @@ public class ActionModeHelper {
             mFastAdapter.withSelectOnLongClick(true);
 
             //actionMode end. deselect everything
-            mFastAdapter.deselect();
+            if (mAutoDeselect)
+                mFastAdapter.deselect();
 
             if (mCallback != null) {
                 //we notify the provided callback


### PR DESCRIPTION
Following features are added:

* ActionMode now shows selection count
* added method to recheck ActionMode on demand (for updating after the selection count has changed manually or to restore action mode after screen rotation)
* added the possibility to provide a custom TitleProvider (this can show something like "x of y", "x/y"  or similar instead of the simple language independent count as the default implementation does