### PR TITLE
SubItems and more

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,6 +34,9 @@
             android:name=".ExpandableSampleActivity"
             android:label="@string/sample_collapsible" />
         <activity
+            android:name=".ExpandableMultiselectDeleteSampleActivity"
+            android:label="@string/sample_collapsible_multi_select_delete" />
+        <activity
             android:name=".StickyHeaderSampleActivity"
             android:label="@string/sample_sticky_header" />
         <activity

--- a/app/src/main/java/com/mikepenz/fastadapter/app/AdvancedSampleActivity.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/AdvancedSampleActivity.java
@@ -142,20 +142,40 @@ public class AdvancedSampleActivity extends AppCompatActivity {
     }
 
     private void setItems() {
-        mHeaderAdapter.add(new SampleItem().withName("Header").withSelectable(false).withIdentifier(1));
+        SampleItem sampleItem = new SampleItem();
+        sampleItem
+                .withName("Header")
+                .withSelectable(false)
+                .withIdentifier(1);
+        mHeaderAdapter.add(sampleItem);
         //fill with some sample data
         List<IItem> items = new ArrayList<>();
         int size = new Random().nextInt(25) + 10;
         for (int i = 1; i <= size; i++) {
             if (i % 6 == 0) {
-                ExpandableItem expandableItem = new ExpandableItem().withName("Test " + i).withHeader(headers[i / 5]).withIdentifier(100 + i);
-                List<IItem> subItems = new LinkedList<>();
+                ExpandableItem<ExpandableItem, ExpandableItem> expandableItem = new ExpandableItem();
+                expandableItem
+                        .withName("Test " + i)
+                        .withHeader(headers[i / 5])
+                        .withIdentifier(100 + i);
+                List<ExpandableItem> subItems = new LinkedList<>();
                 for (int ii = 1; ii <= 3; ii++) {
-                    ExpandableItem subItem = new ExpandableItem().withName("-- SubTest " + ii).withHeader(headers[i / 5]).withIdentifier(1000 + ii);
+                    ExpandableItem<ExpandableItem, SampleItem> subItem = new ExpandableItem();
+                    expandableItem
+                            .withName("-- SubTest " + ii)
+                            .withHeader(headers[i / 5])
+                            .withIdentifier(1000 + ii)
+                            .withParent(expandableItem);
 
-                    List<IItem> subSubItems = new LinkedList<>();
+                    List<SampleItem> subSubItems = new LinkedList<>();
                     for (int iii = 1; iii <= 3; iii++) {
-                        subSubItems.add(new SampleItem().withName("---- SubSubTest " + iii).withHeader(headers[i / 5]).withIdentifier(10000 + iii));
+                        SampleItem<ExpandableItem> subSubItem = new SampleItem();
+                        subSubItem
+                                .withName("---- SubSubTest " + iii)
+                                .withHeader(headers[i / 5])
+                                .withIdentifier(10000 + iii)
+                                .withParent(subItem);
+                        subSubItems.add(subSubItem);
                     }
                     subItem.withSubItems(subSubItems);
 

--- a/app/src/main/java/com/mikepenz/fastadapter/app/ExpandableMultiselectDeleteSampleActivity.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/ExpandableMultiselectDeleteSampleActivity.java
@@ -57,7 +57,7 @@ public class ExpandableMultiselectDeleteSampleActivity extends AppCompatActivity
         fastItemAdapter = new FastItemAdapter<>();
 
         fastItemAdapter
-//                .withPositionBasedStateManagement(false) // this breaks the example!
+                .withPositionBasedStateManagement(false) // this breaks the example!
                 .withSelectable(true)
                 .withMultiSelect(true)
                 .withSelectOnLongClick(true)
@@ -125,7 +125,11 @@ public class ExpandableMultiselectDeleteSampleActivity extends AppCompatActivity
         List<IItem> items = new ArrayList<>();
         for (int i = 0; i < 20; i++) {
             if (i % 2 == 0) {
-                ExpandableItem expandableItem = new ExpandableItem().withName("Test " + (i + 1)).withIdentifier(100 + i);
+                ExpandableItem expandableItem = new ExpandableItem()
+                        .withName("Test " + (i + 1))
+                        .withIdentifier(100 + i)
+//                        .withIsExpanded(true) => breaks example in combination with id based state management
+                        ;
 
                 //add subitems so we can showcase the collapsible functionality
                 List<IItem> subItems = new LinkedList<>();

--- a/app/src/main/java/com/mikepenz/fastadapter/app/ExpandableMultiselectDeleteSampleActivity.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/ExpandableMultiselectDeleteSampleActivity.java
@@ -127,20 +127,27 @@ public class ExpandableMultiselectDeleteSampleActivity extends AppCompatActivity
             if (i % 2 == 0) {
                 ExpandableItem expandableItem = new ExpandableItem()
                         .withName("Test " + (i + 1))
-                        .withIdentifier(100 + i)
+                        .withIdentifier(i + 1)
+                        .withDescription("ID: " + (i + 1))
                         .withIsExpanded(true) // => breaks example in combination with id based state management
                         ;
 
                 //add subitems so we can showcase the collapsible functionality
                 List<IItem> subItems = new LinkedList<>();
                 for (int ii = 1; ii <= 5; ii++) {
-                    subItems.add(new SampleItem().withName("-- Test " + (i + 1) + "." + ii).withIdentifier(1000 + i * 100 + ii));
+                    subItems.add(new SampleItem()
+                            .withName("-- Test " + (i + 1) + "." + ii)
+                            .withIdentifier((i + 1) * 100 + ii)
+                            .withDescription("ID: " + (i + 1) * 100 + ii));
                 }
                 expandableItem.withSubItems(subItems);
 
                 items.add(expandableItem);
             } else {
-                items.add(new SampleItem().withName("Test " + (i + 1)).withIdentifier(100 + i));
+                items.add(new SampleItem()
+                        .withName("Test " + (i + 1))
+                        .withIdentifier(i + 1)
+                        .withDescription("ID: " + (i + 1)));
             }
         }
         fastItemAdapter.add(items);

--- a/app/src/main/java/com/mikepenz/fastadapter/app/ExpandableMultiselectDeleteSampleActivity.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/ExpandableMultiselectDeleteSampleActivity.java
@@ -57,7 +57,7 @@ public class ExpandableMultiselectDeleteSampleActivity extends AppCompatActivity
         fastItemAdapter = new FastItemAdapter<>();
 
         fastItemAdapter
-                .withPositionBasedStateManagement(false) // this breaks the example!
+//                .withPositionBasedStateManagement(false) // this breaks the example!
                 .withSelectable(true)
                 .withMultiSelect(true)
                 .withSelectOnLongClick(true)
@@ -128,7 +128,7 @@ public class ExpandableMultiselectDeleteSampleActivity extends AppCompatActivity
                 ExpandableItem expandableItem = new ExpandableItem()
                         .withName("Test " + (i + 1))
                         .withIdentifier(100 + i)
-//                        .withIsExpanded(true) => breaks example in combination with id based state management
+                        .withIsExpanded(true) // => breaks example in combination with id based state management
                         ;
 
                 //add subitems so we can showcase the collapsible functionality

--- a/app/src/main/java/com/mikepenz/fastadapter/app/ExpandableMultiselectDeleteSampleActivity.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/ExpandableMultiselectDeleteSampleActivity.java
@@ -1,0 +1,208 @@
+package com.mikepenz.fastadapter.app;
+
+import android.os.Bundle;
+import android.support.v4.view.LayoutInflaterCompat;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.view.ActionMode;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.Toolbar;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.Toast;
+
+import com.mikepenz.aboutlibraries.util.UIUtils;
+import com.mikepenz.fastadapter.FastAdapter;
+import com.mikepenz.fastadapter.IAdapter;
+import com.mikepenz.fastadapter.IItem;
+import com.mikepenz.fastadapter.adapters.FastItemAdapter;
+import com.mikepenz.fastadapter.app.items.ExpandableItem;
+import com.mikepenz.fastadapter.app.items.SampleItem;
+import com.mikepenz.fastadapter_extensions.ActionModeHelper;
+import com.mikepenz.fastadapter_extensions.RangeSelectorHelper;
+import com.mikepenz.fastadapter_extensions.utilities.SubItemUtils;
+import com.mikepenz.iconics.context.IconicsLayoutInflater;
+import com.mikepenz.itemanimators.SlideDownAlphaAnimator;
+import com.mikepenz.materialize.MaterializeBuilder;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+public class ExpandableMultiselectDeleteSampleActivity extends AppCompatActivity {
+    //save our FastAdapter
+    private FastItemAdapter<IItem> fastItemAdapter;
+    private ActionModeHelper mActionModeHelper;
+    private RangeSelectorHelper mRangeSelectorHelper;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        findViewById(android.R.id.content).setSystemUiVisibility(findViewById(android.R.id.content).getSystemUiVisibility() | View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+        //as we use an icon from Android-Iconics via xml we add the IconicsLayoutInflater
+        //https://github.com/mikepenz/Android-Iconics
+        LayoutInflaterCompat.setFactory(getLayoutInflater(), new IconicsLayoutInflater(getDelegate()));
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_sample);
+
+        // Handle Toolbar
+        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+        getSupportActionBar().setTitle(R.string.sample_collapsible);
+
+        //style our ui
+        new MaterializeBuilder().withActivity(this).build();
+
+        //create our FastAdapter
+        fastItemAdapter = new FastItemAdapter<>();
+
+        fastItemAdapter
+//                .withPositionBasedStateManagement(false) // this breaks the example!
+                .withSelectable(true)
+                .withMultiSelect(true)
+                .withSelectOnLongClick(true)
+                .withOnPreClickListener(new FastAdapter.OnClickListener<IItem>() {
+                    @Override
+                    public boolean onClick(View v, IAdapter<IItem> adapter, IItem item, int position) {
+                        //we handle the default onClick behavior for the actionMode. This will return null if it didn't do anything and you can handle a normal onClick
+                        Boolean res = mActionModeHelper.onClick(ExpandableMultiselectDeleteSampleActivity.this, item);
+                        // in this example, we want to consume a click, if the ActionModeHelper will remove the ActionMode
+                        // so that the click listener is not fired
+                        if (res != null && !res)
+                            return true;
+                        return res != null ? res : false;
+                    }
+                })
+                .withOnClickListener(new FastAdapter.OnClickListener<IItem>() {
+                    @Override
+                    public boolean onClick(View v, IAdapter<IItem> adapter, IItem item, int position) {
+                        // check if the actionMode consumes the click. This returns true, if it does, false if not
+                        if (!mActionModeHelper.isActive())
+                            Toast.makeText(ExpandableMultiselectDeleteSampleActivity.this, ((SampleItem)item).name + " clicked!", Toast.LENGTH_SHORT).show();
+//                        else
+//                            mFastAdapter.notifyItemChanged(position); // im Bsp. ist das nicht nötig, k.A. warum ich das machen muss!
+                        mRangeSelectorHelper.onClick();
+                        return false;
+                    }
+                })
+                .withOnPreLongClickListener(new FastAdapter.OnLongClickListener<IItem>() {
+                    @Override
+                    public boolean onLongClick(View v, IAdapter<IItem> adapter, IItem item, int position) {
+                        ActionMode actionMode = mActionModeHelper.onLongClick((AppCompatActivity) ExpandableMultiselectDeleteSampleActivity.this, position);
+                        mRangeSelectorHelper.onLongClick(position);
+                        if (actionMode != null) {
+                            //we want color our CAB
+                            ExpandableMultiselectDeleteSampleActivity.this.findViewById(R.id.action_mode_bar).setBackgroundColor(UIUtils.getThemeColorFromAttrOrRes(ExpandableMultiselectDeleteSampleActivity.this, R.attr.colorPrimary, R.color.material_drawer_primary));
+                        }
+
+                        //if we have no actionMode we do not consume the event
+                        return actionMode != null;
+                    }
+                });
+
+        // provide a custom title provider that even shows the count of sub items only!
+        // this may not be what you want though, but shows the usage of the SubItemUtils function
+        mActionModeHelper = new ActionModeHelper(fastItemAdapter, R.menu.cab, new ActionBarCallBack())
+                .withTitleProvider(new ActionModeHelper.ActionModeTitleProvider() {
+                    @Override
+                    public String getTitle(int selected) {
+                        return selected + "/" + SubItemUtils.countItems(fastItemAdapter, false);
+                    }
+                });
+
+        // this will take care of selecting range of items via long press on the first and afterwards on the last item
+        mRangeSelectorHelper = new RangeSelectorHelper(fastItemAdapter)
+                .withSavedInstanceState(savedInstanceState)
+                .withActionModeHelper(mActionModeHelper);
+
+        //get our recyclerView and do basic setup
+        RecyclerView rv = (RecyclerView) findViewById(R.id.rv);
+        rv.setLayoutManager(new LinearLayoutManager(this));
+        rv.setItemAnimator(new SlideDownAlphaAnimator());
+        rv.setAdapter(fastItemAdapter);
+
+        //fill with some sample data
+        List<IItem> items = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            if (i % 2 == 0) {
+                ExpandableItem expandableItem = new ExpandableItem().withName("Test " + (i + 1)).withIdentifier(100 + i);
+
+                //add subitems so we can showcase the collapsible functionality
+                List<IItem> subItems = new LinkedList<>();
+                for (int ii = 1; ii <= 5; ii++) {
+                    subItems.add(new SampleItem().withName("-- Test " + (i + 1) + "." + ii).withIdentifier(1000 + i * 100 + ii));
+                }
+                expandableItem.withSubItems(subItems);
+
+                items.add(expandableItem);
+            } else {
+                items.add(new SampleItem().withName("Test " + (i + 1)).withIdentifier(100 + i));
+            }
+        }
+        fastItemAdapter.add(items);
+
+        //restore selections (this has to be done after the items were added
+        fastItemAdapter.withSavedInstanceState(savedInstanceState);
+
+        //set the back arrow in the toolbar
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        getSupportActionBar().setHomeButtonEnabled(false);
+
+        // restore action mode
+        if (savedInstanceState != null)
+            mActionModeHelper.checkActionMode(this);
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        //add the values which need to be saved from the adapter to the bundel
+        outState = fastItemAdapter.saveInstanceState(outState);
+        outState = mRangeSelectorHelper.saveInstanceState(outState);
+        super.onSaveInstanceState(outState);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        //handle the click on the back arrow click
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                onBackPressed();
+                return true;
+
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+    }
+
+    class ActionBarCallBack implements ActionMode.Callback {
+
+        @Override
+        public boolean onCreateActionMode(ActionMode mode, Menu menu)
+        {
+            return true;
+        }
+
+        @Override
+        public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
+
+            // delete the selected items with the SubItemUtils to correctly handle sub items
+            // this will even delete empty headers if you want to
+            List<IItem> deleted = SubItemUtils.deleteSelected(fastItemAdapter, true, true);
+            //as we no longer have a selection so the actionMode can be finished
+            mode.finish();
+            //we consume the event
+            return true;
+        }
+
+        @Override
+        public void onDestroyActionMode(ActionMode mode) {
+            // reset the range selector
+            mRangeSelectorHelper.reset();
+        }
+
+        @Override
+        public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
+            return false;
+        }
+    }
+}

--- a/app/src/main/java/com/mikepenz/fastadapter/app/ExpandableMultiselectDeleteSampleActivity.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/ExpandableMultiselectDeleteSampleActivity.java
@@ -57,7 +57,7 @@ public class ExpandableMultiselectDeleteSampleActivity extends AppCompatActivity
         fastItemAdapter = new FastItemAdapter<>();
 
         fastItemAdapter
-//                .withPositionBasedStateManagement(false) // this breaks the example!
+                .withPositionBasedStateManagement(false)
                 .withSelectable(true)
                 .withMultiSelect(true)
                 .withSelectOnLongClick(true)
@@ -129,7 +129,7 @@ public class ExpandableMultiselectDeleteSampleActivity extends AppCompatActivity
                         .withName("Test " + (i + 1))
                         .withIdentifier(i + 1)
                         .withDescription("ID: " + (i + 1))
-                        .withIsExpanded(true) // => breaks example in combination with id based state management
+                        //.withIsExpanded(true) don't use this in such a setup, use adapter.expand() to expand all items instead
                         ;
 
                 //add subitems so we can showcase the collapsible functionality
@@ -151,6 +151,7 @@ public class ExpandableMultiselectDeleteSampleActivity extends AppCompatActivity
             }
         }
         fastItemAdapter.add(items);
+        fastItemAdapter.expand();
 
         //restore selections (this has to be done after the items were added
         fastItemAdapter.withSavedInstanceState(savedInstanceState);

--- a/app/src/main/java/com/mikepenz/fastadapter/app/ExpandableSampleActivity.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/ExpandableSampleActivity.java
@@ -56,12 +56,20 @@ public class ExpandableSampleActivity extends AppCompatActivity {
         List<IItem> items = new ArrayList<>();
         for (int i = 1; i <= 100; i++) {
             if (i % 10 == 0) {
-                ExpandableItem expandableItem = new ExpandableItem().withName("Test " + i).withIdentifier(100 + 1);
+                ExpandableItem expandableItem = new ExpandableItem();
+                expandableItem
+                        .withName("Test " + i)
+                        .withIdentifier(100 + 1);
 
                 //add subitems so we can showcase the collapsible functionality
                 List<IItem> subItems = new LinkedList<>();
                 for (int ii = 1; ii <= 5; ii++) {
-                    subItems.add(new SampleItem().withName("-- Test " + ii).withIdentifier(1000 + ii));
+                    SampleItem sampleItem = new SampleItem();
+                    sampleItem
+                            .withName("-- Test " + ii)
+                            .withParent(expandableItem)
+                            .withIdentifier(1000 + ii);
+                    subItems.add(sampleItem);
                 }
                 expandableItem.withSubItems(subItems);
 

--- a/app/src/main/java/com/mikepenz/fastadapter/app/IconGridActivity.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/IconGridActivity.java
@@ -86,11 +86,18 @@ public class IconGridActivity extends AppCompatActivity {
         ArrayList<ExpandableItem> items = new ArrayList<>(Iconics.getRegisteredFonts(this).size());
         for (ITypeface font : mFonts) {
             //we set the identifier from the count here, as I need a stable ID in the sample to showcase the state restore
-            ExpandableItem expandableItem = new ExpandableItem().withName(font.getFontName()).withIdentifier(count);
+            ExpandableItem expandableItem = new ExpandableItem();
+            expandableItem
+                    .withName(font.getFontName())
+                    .withIdentifier(count);
 
             ArrayList<IItem> icons = new ArrayList<>();
             for (String icon : font.getIcons()) {
-                icons.add(new IconItem().withIcon(font.getIcon(icon)));
+                IconItem iconItem = new IconItem();
+                iconItem
+                        .withIcon(font.getIcon(icon))
+                        .withParent(expandableItem);
+                icons.add(iconItem);
             }
             expandableItem.withSubItems(icons);
 

--- a/app/src/main/java/com/mikepenz/fastadapter/app/MultiselectSampleActivity.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/MultiselectSampleActivity.java
@@ -111,10 +111,19 @@ public class MultiselectSampleActivity extends AppCompatActivity {
         rv.setAdapter(itemAdapter.wrap(headerAdapter.wrap(mFastAdapter)));
 
         //fill with some sample data
-        headerAdapter.add(new SampleItem().withName("Header").withIdentifier(1).withSelectable(false));
+        SampleItem sampleItem = new SampleItem();
+        sampleItem
+                .withName("Header")
+                .withIdentifier(1)
+                .withSelectable(false);
+        headerAdapter.add(sampleItem);
         List<SampleItem> items = new ArrayList<>();
         for (int i = 1; i <= 100; i++) {
-            items.add(new SampleItem().withName("Test " + i).withIdentifier(100 + i));
+            SampleItem item = new SampleItem();
+            item
+                    .withName("Test " + i).
+                    withIdentifier(100 + i);
+            items.add(item);
         }
         itemAdapter.add(items);
 

--- a/app/src/main/java/com/mikepenz/fastadapter/app/SampleActivity.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/SampleActivity.java
@@ -80,6 +80,7 @@ public class SampleActivity extends AppCompatActivity {
                         new PrimaryDrawerItem().withName(R.string.sample_sort).withDescription(R.string.sample_sort_descr).withSelectable(false).withIdentifier(14).withIcon(MaterialDesignIconic.Icon.gmi_sort_by_alpha),
                         new PrimaryDrawerItem().withName(R.string.sample_mopub).withDescription(R.string.sample_mopub_descr).withSelectable(false).withIdentifier(15).withIcon(MaterialDesignIconic.Icon.gmi_accounts_list),
                         new PrimaryDrawerItem().withName(R.string.sample_realm_list).withDescription(R.string.sample_realm_list_descr).withSelectable(false).withIdentifier(16).withIcon(MaterialDesignIconic.Icon.gmi_format_color_text),
+                        new PrimaryDrawerItem().withName(R.string.sample_collapsible_multi_select_delete).withDescription(R.string.sample_collapsible_multi_select_delete_descr).withSelectable(false).withIdentifier(17).withIcon(MaterialDesignIconic.Icon.gmi_check_all),
                         new DividerDrawerItem(),
                         new PrimaryDrawerItem().withName(R.string.open_source).withSelectable(false).withIdentifier(100).withIcon(MaterialDesignIconic.Icon.gmi_github)
                 )
@@ -120,6 +121,8 @@ public class SampleActivity extends AppCompatActivity {
                                 intent = new Intent(SampleActivity.this, MopubAdsActivity.class);
                             } else if (drawerItem.getIdentifier() == 16) {
                                 intent = new Intent(SampleActivity.this, RealmActivity.class);
+                            } else if (drawerItem.getIdentifier() == 17) {
+                                intent = new Intent(SampleActivity.this, ExpandableMultiselectDeleteSampleActivity.class);
                             } else if (drawerItem.getIdentifier() == 100) {
                                 intent = new LibsBuilder()
                                         .withFields(R.string.class.getFields())

--- a/app/src/main/java/com/mikepenz/fastadapter/app/SimpleItemListActivity.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/SimpleItemListActivity.java
@@ -104,7 +104,11 @@ public class SimpleItemListActivity extends AppCompatActivity implements ItemTou
         for (String s : ALPHABET) {
             int count = new Random().nextInt(20);
             for (int i = 1; i <= count; i++) {
-                items.add(new SampleItem().withName(s + " Test " + x).withIdentifier(100 + x));
+                SampleItem item = new SampleItem();
+                item
+                        .withName(s + " Test " + x)
+                        .withIdentifier(100 + x);
+                items.add(item);
                 x++;
             }
         }

--- a/app/src/main/java/com/mikepenz/fastadapter/app/items/ExpandableItem.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/items/ExpandableItem.java
@@ -13,6 +13,7 @@ import com.mikepenz.fastadapter.FastAdapter;
 import com.mikepenz.fastadapter.IAdapter;
 import com.mikepenz.fastadapter.IExpandable;
 import com.mikepenz.fastadapter.IItem;
+import com.mikepenz.fastadapter.ISubItem;
 import com.mikepenz.fastadapter.app.R;
 import com.mikepenz.fastadapter.items.AbstractItem;
 import com.mikepenz.fastadapter.utils.FastAdapterUIUtils;
@@ -28,7 +29,7 @@ import butterknife.ButterKnife;
 /**
  * Created by mikepenz on 28.12.15.
  */
-public class ExpandableItem extends AbstractItem<ExpandableItem, ExpandableItem.ViewHolder> implements IExpandable<ExpandableItem, IItem> {
+public class ExpandableItem<T extends IItem & IExpandable, S extends IItem & ISubItem> extends AbstractItem<ExpandableItem<T, S>, ExpandableItem.ViewHolder> implements IExpandable<ExpandableItem, S>, ISubItem<ExpandableItem, T> {
     //the static ViewHolderFactory which will be used to generate the ViewHolder for this Item
     private static final ViewHolderFactory<? extends ViewHolder> FACTORY = new ItemFactory();
 
@@ -36,32 +37,33 @@ public class ExpandableItem extends AbstractItem<ExpandableItem, ExpandableItem.
     public StringHolder name;
     public StringHolder description;
 
-    private List<IItem> mSubItems;
+    private List<S> mSubItems;
+    private T mParent;
     private boolean mExpanded = false;
 
     private FastAdapter.OnClickListener<ExpandableItem> mOnClickListener;
 
-    public ExpandableItem withHeader(String header) {
+    public ExpandableItem<T, S> withHeader(String header) {
         this.header = header;
         return this;
     }
 
-    public ExpandableItem withName(String Name) {
+    public ExpandableItem<T, S> withName(String Name) {
         this.name = new StringHolder(Name);
         return this;
     }
 
-    public ExpandableItem withName(@StringRes int NameRes) {
+    public ExpandableItem<T, S> withName(@StringRes int NameRes) {
         this.name = new StringHolder(NameRes);
         return this;
     }
 
-    public ExpandableItem withDescription(String description) {
+    public ExpandableItem<T, S> withDescription(String description) {
         this.description = new StringHolder(description);
         return this;
     }
 
-    public ExpandableItem withDescription(@StringRes int descriptionRes) {
+    public ExpandableItem<T, S> withDescription(@StringRes int descriptionRes) {
         this.description = new StringHolder(descriptionRes);
         return this;
     }
@@ -72,13 +74,13 @@ public class ExpandableItem extends AbstractItem<ExpandableItem, ExpandableItem.
     }
 
     @Override
-    public ExpandableItem withIsExpanded(boolean expanded) {
+    public ExpandableItem<T, S> withIsExpanded(boolean expanded) {
         mExpanded = expanded;
         return this;
     }
 
     @Override
-    public List<IItem> getSubItems() {
+    public List<S> getSubItems() {
         return mSubItems;
     }
 
@@ -87,8 +89,20 @@ public class ExpandableItem extends AbstractItem<ExpandableItem, ExpandableItem.
         return true;
     }
 
-    public ExpandableItem withSubItems(List<IItem> subItems) {
+    @Override
+    public ExpandableItem<T, S> withSubItems(List<S> subItems) {
         this.mSubItems = subItems;
+        return this;
+    }
+
+    @Override
+    public T getParent() {
+        return mParent;
+    }
+
+    @Override
+    public ExpandableItem<T, S> withParent(T parent) {
+        this.mParent = parent;
         return this;
     }
 
@@ -96,13 +110,13 @@ public class ExpandableItem extends AbstractItem<ExpandableItem, ExpandableItem.
         return mOnClickListener;
     }
 
-    public ExpandableItem withOnClickListener(FastAdapter.OnClickListener<ExpandableItem> mOnClickListener) {
+    public ExpandableItem<T, S> withOnClickListener(FastAdapter.OnClickListener<ExpandableItem> mOnClickListener) {
         this.mOnClickListener = mOnClickListener;
         return this;
     }
 
     //we define a clickListener in here so we can directly animate
-    final private FastAdapter.OnClickListener<ExpandableItem> onClickListener = new FastAdapter.OnClickListener<ExpandableItem>() {
+    final private FastAdapter.OnClickListener<ExpandableItem<T, S>> onClickListener = new FastAdapter.OnClickListener<ExpandableItem<T, S>>() {
         @Override
         public boolean onClick(View v, IAdapter adapter, ExpandableItem item, int position) {
             if (item.getSubItems() != null) {
@@ -123,7 +137,7 @@ public class ExpandableItem extends AbstractItem<ExpandableItem, ExpandableItem.
      * @return
      */
     @Override
-    public FastAdapter.OnClickListener<ExpandableItem> getOnItemClickListener() {
+    public FastAdapter.OnClickListener<ExpandableItem<T, S>> getOnItemClickListener() {
         return onClickListener;
     }
 

--- a/app/src/main/java/com/mikepenz/fastadapter/app/items/HeaderSelectionItem.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/items/HeaderSelectionItem.java
@@ -1,0 +1,58 @@
+package com.mikepenz.fastadapter.app.items;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.support.annotation.StringRes;
+
+import com.mikepenz.fastadapter.IExpandable;
+import com.mikepenz.fastadapter.IItem;
+import com.mikepenz.fastadapter.ISubItem;
+import com.mikepenz.fastadapter.items.AbstractItem;
+import com.mikepenz.fastadapter.utils.FastAdapterUIUtils;
+import com.mikepenz.fastadapter_extensions.utilities.SubItemUtils;
+import com.mikepenz.materialdrawer.holder.StringHolder;
+import com.mikepenz.materialize.util.UIUtils;
+
+import java.util.List;
+
+/**
+ * Created by flisar on 21.09.2016.
+ */
+
+public class HeaderSelectionItem<T extends IItem & IExpandable, S extends IItem & ISubItem> extends ExpandableItem<T, S> {
+
+    private ISubSelectionProvider mSubSelectionProvider;
+
+    public HeaderSelectionItem<T, S> withSubSelectionProvider(ISubSelectionProvider subSelectionProvider) {
+        this.mSubSelectionProvider = subSelectionProvider;
+        return this;
+    }
+
+    @Override
+    public void bindView(ViewHolder viewHolder, List payloads) {
+        super.bindView(viewHolder, payloads);
+
+        //get the context
+        Context ctx = viewHolder.itemView.getContext();
+
+        //set the background for the item
+        UIUtils.setBackground(viewHolder.view, FastAdapterUIUtils.getSelectableBackground(ctx, Color.RED, true));
+        //set the text for the name
+        StringHolder.applyTo(name, viewHolder.name);
+        //set the text for the description or hide
+
+        int selectedSubItems = 0;
+        if (mSubSelectionProvider != null)
+            selectedSubItems = mSubSelectionProvider.getSelectedSubItems();
+        StringHolder descr = new StringHolder(description.getText());
+        if (selectedSubItems > 0)
+            descr.setText("Selected children: " + selectedSubItems + "/" + getSubItems().size());
+        StringHolder.applyToOrHide(descr, viewHolder.description);
+
+        viewHolder.description.setTextColor(selectedSubItems == 0 ? Color.BLACK : Color.RED);
+    }
+
+    public interface ISubSelectionProvider {
+        int getSelectedSubItems();
+    }
+}

--- a/app/src/main/java/com/mikepenz/fastadapter/app/items/IconItem.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/items/IconItem.java
@@ -4,6 +4,9 @@ import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.TextView;
 
+import com.mikepenz.fastadapter.IExpandable;
+import com.mikepenz.fastadapter.IItem;
+import com.mikepenz.fastadapter.ISubItem;
 import com.mikepenz.fastadapter.app.R;
 import com.mikepenz.fastadapter.items.AbstractItem;
 import com.mikepenz.fastadapter.utils.ViewHolderFactory;
@@ -18,11 +21,12 @@ import butterknife.ButterKnife;
 /**
  * Created by mikepenz on 28.12.15.
  */
-public class IconItem extends AbstractItem<IconItem, IconItem.ViewHolder> {
+public class IconItem<T extends IItem & IExpandable> extends AbstractItem<IconItem<T>, IconItem.ViewHolder> implements ISubItem<IconItem, T>{
     //the static ViewHolderFactory which will be used to generate the ViewHolder for this Item
     private static final ViewHolderFactory<? extends ViewHolder> FACTORY = new ItemFactory();
 
     public IIcon mIcon;
+    private T mParent;
 
     /**
      * setter method for the Icon
@@ -32,6 +36,17 @@ public class IconItem extends AbstractItem<IconItem, IconItem.ViewHolder> {
      */
     public IconItem withIcon(IIcon icon) {
         this.mIcon = icon;
+        return this;
+    }
+
+    @Override
+    public T getParent() {
+        return mParent;
+    }
+
+    @Override
+    public IconItem withParent(T parent) {
+        mParent = parent;
         return this;
     }
 

--- a/app/src/main/java/com/mikepenz/fastadapter/app/items/SampleItem.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/items/SampleItem.java
@@ -10,6 +10,7 @@ import android.widget.TextView;
 import com.mikepenz.fastadapter.IDraggable;
 import com.mikepenz.fastadapter.IExpandable;
 import com.mikepenz.fastadapter.IItem;
+import com.mikepenz.fastadapter.ISubItem;
 import com.mikepenz.fastadapter.app.R;
 import com.mikepenz.fastadapter.items.AbstractItem;
 import com.mikepenz.fastadapter.utils.FastAdapterUIUtils;
@@ -25,7 +26,7 @@ import butterknife.ButterKnife;
 /**
  * Created by mikepenz on 28.12.15.
  */
-public class SampleItem extends AbstractItem<SampleItem, SampleItem.ViewHolder> implements IExpandable<SampleItem, IItem>, IDraggable<SampleItem, IItem> {
+public class SampleItem<S extends IItem & IExpandable> extends AbstractItem<SampleItem<S>, SampleItem.ViewHolder> implements IExpandable<SampleItem, SampleItem>, ISubItem<SampleItem, S>, IDraggable<SampleItem, IItem> {
     //the static ViewHolderFactory which will be used to generate the ViewHolder for this Item
     private static final ViewHolderFactory<? extends ViewHolder> FACTORY = new ItemFactory();
 
@@ -33,31 +34,32 @@ public class SampleItem extends AbstractItem<SampleItem, SampleItem.ViewHolder> 
     public StringHolder name;
     public StringHolder description;
 
-    private List<IItem> mSubItems;
+    private List<SampleItem> mSubItems;
+    private S mParent;
     private boolean mExpanded = false;
     private boolean mIsDraggable = true;
 
-    public SampleItem withHeader(String header) {
+    public SampleItem<S> withHeader(String header) {
         this.header = header;
         return this;
     }
 
-    public SampleItem withName(String Name) {
+    public SampleItem<S> withName(String Name) {
         this.name = new StringHolder(Name);
         return this;
     }
 
-    public SampleItem withName(@StringRes int NameRes) {
+    public SampleItem<S> withName(@StringRes int NameRes) {
         this.name = new StringHolder(NameRes);
         return this;
     }
 
-    public SampleItem withDescription(String description) {
+    public SampleItem<S> withDescription(String description) {
         this.description = new StringHolder(description);
         return this;
     }
 
-    public SampleItem withDescription(@StringRes int descriptionRes) {
+    public SampleItem<S> withDescription(@StringRes int descriptionRes) {
         this.description = new StringHolder(descriptionRes);
         return this;
     }
@@ -68,7 +70,7 @@ public class SampleItem extends AbstractItem<SampleItem, SampleItem.ViewHolder> 
     }
 
     @Override
-    public SampleItem withIsExpanded(boolean expaned) {
+    public SampleItem<S> withIsExpanded(boolean expaned) {
         mExpanded = expaned;
         return this;
     }
@@ -79,12 +81,24 @@ public class SampleItem extends AbstractItem<SampleItem, SampleItem.ViewHolder> 
     }
 
     @Override
-    public List<IItem> getSubItems() {
+    public List<SampleItem> getSubItems() {
         return mSubItems;
     }
 
-    public SampleItem withSubItems(List<IItem> subItems) {
+    @Override
+    public SampleItem<S> withSubItems(List<SampleItem> subItems) {
         this.mSubItems = subItems;
+        return this;
+    }
+
+    @Override
+    public S getParent() {
+        return mParent;
+    }
+
+    @Override
+    public SampleItem<S> withParent(S parent) {
+        this.mParent = parent;
         return this;
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
     <string name="sample_image_list_descr">View Click Listener</string>
     <string name="sample_multi_select">MultiSelect Sample</string>
     <string name="sample_multi_select_descr">MultiSelect, CAB, Remove, Undo</string>
+    <string name="sample_collapsible_multi_select_delete">Expandable MultiSelect Delete Sample</string>
+    <string name="sample_collapsible_multi_select_delete_descr">Expandable, MultiSelect, CAB, Remove</string>
     <string name="sample_collapsible">Expandable Sample</string>
     <string name="sample_collapsible_descr">Expandable, Select</string>
     <string name="sample_sticky_header">StickyHeader Sample</string>

--- a/library-extensions-firebase/src/main/java/com/mikepenz/fastadapter_extensions/firebase/FirebaseItemAdapter.java
+++ b/library-extensions-firebase/src/main/java/com/mikepenz/fastadapter_extensions/firebase/FirebaseItemAdapter.java
@@ -24,6 +24,7 @@ import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.Query;
 import com.mikepenz.fastadapter.IExpandable;
 import com.mikepenz.fastadapter.IItem;
+import com.mikepenz.fastadapter.ISubItem;
 import com.mikepenz.fastadapter.adapters.ItemAdapter;
 
 import java.util.ArrayList;
@@ -198,7 +199,7 @@ public class FirebaseItemAdapter<Item extends IItem> extends ItemAdapter<Item> {
     }
 
     @Override
-    public <T> T setSubItems(IExpandable<T, Item> collapsible, List<Item> subItems) {
+    public <T extends IItem & IExpandable<T, S>, S extends IItem & ISubItem<Item, T>> T setSubItems(T collapsible, List<S> subItems) {
         throw new UnsupportedOperationException("this is not supported by the FirebaseItemAdapter");
     }
 

--- a/library-extensions-realm/src/main/java/io/realm/RealmItemAdapter.java
+++ b/library-extensions-realm/src/main/java/io/realm/RealmItemAdapter.java
@@ -22,6 +22,7 @@ import android.support.v7.widget.RecyclerView;
 
 import com.mikepenz.fastadapter.IExpandable;
 import com.mikepenz.fastadapter.IItem;
+import com.mikepenz.fastadapter.ISubItem;
 import com.mikepenz.fastadapter.adapters.ItemAdapter;
 import com.mikepenz.fastadapter.utils.IdDistributor;
 
@@ -203,7 +204,7 @@ public class RealmItemAdapter<Item extends RealmModel & IItem> extends ItemAdapt
     }
 
     @Override
-    public <T> T setSubItems(IExpandable<T, Item> collapsible, List<Item> subItems) {
+    public <T extends IItem & IExpandable<T, S>, S extends IItem & ISubItem<Item, T>> T setSubItems(T collapsible, List<S> subItems) {
         throw new UnsupportedOperationException("this is not supported by the RealmRecyclerViewAdapter");
     }
 

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/RangeSelectorHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/RangeSelectorHelper.java
@@ -64,7 +64,7 @@ public class RangeSelectorHelper {
                     mActionModeHelper.checkActionMode(null); // works with null as well, as the ActionMode is active for sure!
                 return true;
             }
-        } else {
+        } else if (mLastLongPressIndex != index){
             // select all items in the range between the two long clicks
             selectRange(mLastLongPressIndex, index, true);
             // reset the index

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/RangeSelectorHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/RangeSelectorHelper.java
@@ -1,0 +1,152 @@
+package com.mikepenz.fastadapter_extensions;
+
+import android.os.Bundle;
+
+import com.mikepenz.fastadapter.adapters.FastItemAdapter;
+import com.mikepenz.fastadapter.utils.AdapterUtil;
+
+import java.util.ArrayList;
+
+/**
+ * Created by Michael on 15.09.2016.
+ */
+public class RangeSelectorHelper {
+
+    protected static final String BUNDLE_LAST_LONG_PRESS = "bundle_last_long_press";
+
+    private FastItemAdapter mFastAdapter;
+    private ActionModeHelper mActionModeHelper;
+
+    private Integer mLastLongPressIndex;
+
+    public RangeSelectorHelper(FastItemAdapter adapter) {
+        mFastAdapter = adapter;
+    }
+
+    /**
+     * set the ActionModeHelper, if want to notify it after a range was selected
+     * so that it can update the ActionMode title
+     */
+    public RangeSelectorHelper withActionModeHelper(ActionModeHelper actionModeHelper) {
+        mActionModeHelper = actionModeHelper;
+        return this;
+    }
+
+    /**
+     * resets the last long pressed index, we only want to respect two consecutive long clicks for selecting a range of items
+     */
+    public void onClick() {
+        reset();
+    }
+
+    /**
+     * resets the last long pressed index, we only want to respect two consecutive long clicks for selecting a range of items
+     */
+    public void reset() {
+        mLastLongPressIndex = null;
+    }
+
+    /**
+     * will take care to save the long pressed index
+     * or to select all items in the range between the current long pressed item and the last long pressed item
+     *
+     * @param index the index of the long pressed item
+     * @return true, if the long press was handled
+     */
+    public boolean onLongClick(int index) {
+        if (mLastLongPressIndex == null) {
+            // we only consider long presses on not selected items
+            if (mFastAdapter.getAdapterItem(index).isSelectable()) {
+                mLastLongPressIndex = index;
+                // we select this item as well
+                mFastAdapter.select(index);
+                if (mActionModeHelper != null)
+                    mActionModeHelper.checkActionMode(null); // works with null as well, as the ActionMode is active for sure!
+                return true;
+            }
+        } else {
+            // select all items in the range between the two long clicks
+            selectRange(mLastLongPressIndex, index, true);
+            // reset the index
+            mLastLongPressIndex = null;
+        }
+        return false;
+    }
+
+    private void selectRange(int from, int to, boolean select) {
+        if (from == to)
+            return;
+
+        if (from > to) {
+            int temp = from;
+            from = to;
+            to = temp;
+        }
+
+        for (int i = from; i <= to; i++) {
+            if (mFastAdapter.getAdapterItem(i).isSelectable()) {
+                if (select)
+                    mFastAdapter.select(i);
+                else
+                    mFastAdapter.deselect(i);
+            }
+        }
+
+        if (mActionModeHelper != null)
+            mActionModeHelper.checkActionMode(null); // works with null as well, as the ActionMode is active for sure!
+    }
+
+    /**
+     * add the values to the bundle for saveInstanceState
+     *
+     * @param savedInstanceState If the activity is being re-initialized after
+     *                           previously being shut down then this Bundle contains the data it most
+     *                           recently supplied in Note: Otherwise it is null.
+     * @return the passed bundle with the newly added data
+     */
+    public Bundle saveInstanceState(Bundle savedInstanceState) {
+        return saveInstanceState(savedInstanceState, "");
+    }
+
+    /**
+     * add the values to the bundle for saveInstanceState
+     *
+     * @param savedInstanceState If the activity is being re-initialized after
+     *                           previously being shut down then this Bundle contains the data it most
+     *                           recently supplied in Note: Otherwise it is null.
+     * @param prefix             a prefix added to the savedInstance key so we can store multiple states
+     * @return the passed bundle with the newly added data
+     */
+    public Bundle saveInstanceState(Bundle savedInstanceState, String prefix) {
+        if (savedInstanceState != null && mLastLongPressIndex != null)
+            savedInstanceState.putInt(BUNDLE_LAST_LONG_PRESS, mLastLongPressIndex);
+        return savedInstanceState;
+    }
+
+    /**
+     * restore the index of the last long pressed index
+     * @param savedInstanceState If the activity is being re-initialized after
+     *                           previously being shut down then this Bundle contains the data it most
+     *                           recently supplied in Note: Otherwise it is null.
+     * @return this
+     */
+    public RangeSelectorHelper withSavedInstanceState(Bundle savedInstanceState) {
+        return withSavedInstanceState(savedInstanceState, "");
+    }
+
+    /**
+     * restore the index of the last long pressed index
+     * IMPORTANT! Call this method only after all items where added to the adapters again. Otherwise it may select wrong items!
+     *
+     * @param savedInstanceState If the activity is being re-initialized after
+     *                           previously being shut down then this Bundle contains the data it most
+     *                           recently supplied in Note: Otherwise it is null.
+     * @param prefix             a prefix added to the savedInstance key so we can store multiple states
+     * @return this
+     */
+    public RangeSelectorHelper withSavedInstanceState(Bundle savedInstanceState, String prefix) {
+        if (savedInstanceState != null && savedInstanceState.containsKey(BUNDLE_LAST_LONG_PRESS))
+            mLastLongPressIndex = savedInstanceState.getInt(BUNDLE_LAST_LONG_PRESS);
+        return this;
+    }
+}

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/RangeSelectorHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/RangeSelectorHelper.java
@@ -40,7 +40,7 @@ public class RangeSelectorHelper {
     }
 
     /**
-     * resets the last long pressed index, we only want to respect two consecutive long clicks for selecting a range of items
+     * resets the last long pressed index, we only want to respect two consecutive long presses for selecting a range of items
      */
     public void reset() {
         mLastLongPressIndex = null;

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/SubItemUtils.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/SubItemUtils.java
@@ -1,0 +1,135 @@
+package com.mikepenz.fastadapter_extensions.utilities;
+
+import android.support.v4.util.Pair;
+
+import com.mikepenz.fastadapter.FastAdapter;
+import com.mikepenz.fastadapter.IExpandable;
+import com.mikepenz.fastadapter.IItem;
+import com.mikepenz.fastadapter.adapters.FastItemAdapter;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Queue;
+import java.util.Set;
+
+/**
+ * Created by flisar on 15.09.2016.
+ */
+public class SubItemUtils
+{
+    /**
+     * counts the items in the adapter, respecting subitems regardless of there current visibility
+     *
+     * @param countHeaders      if true, headers will be counted as well
+     * @return number of items in the adapter
+     */
+    public static int countItems(final FastItemAdapter adapter, boolean countHeaders) {
+        return countItems(adapter, adapter.getAdapterItems(), countHeaders, false);
+    }
+
+    private static int countItems(final FastItemAdapter adapter, List<IItem> items, boolean countHeaders, boolean subItemsOnly) {
+        if (items == null || items.size() == 0)
+            return 0;
+
+        int count = 0;
+        int itemCount = items.size();
+        IItem item;
+        List<IItem> subItems;
+        for (int i = 0; i < itemCount; i++) {
+            item = items.get(i);
+            if (item instanceof IExpandable && ((IExpandable)item).getSubItems() != null) {
+                subItems = ((IExpandable)item).getSubItems();
+                count += subItems != null ? subItems.size() : 0;
+                count += countItems(adapter, subItems, countHeaders, true);
+                if (countHeaders)
+                    count++;
+            }
+            // in some cases, we must manually check, if the item is a sub item, process is optimised as much as possible via the subItemsOnly parameter already
+            // sub items will be counted in above if statement!
+            else if (!subItemsOnly && getParent(adapter, item, adapter.getAdapterPosition(item)) == null)
+                count++;
+        }
+        return count;
+    }
+
+    // TODO: this is the bottleneck in this class, this may be slow in big lists!
+    // IMPROVEMENT POSSIBLE?
+    private static Pair<IItem, Integer> getParent(FastItemAdapter adapter, IItem item, int itemPosition) {
+        int parentIndex = itemPosition - 1;
+        IItem parent;
+        List<IItem> subItems;
+        while (parentIndex >= 0) {
+            parent = adapter.getAdapterItem(parentIndex);
+            if (parent instanceof IExpandable && ((IExpandable)parent).getSubItems() != null) {
+                // it is possible, that normal items are positioned between expandable ones
+                // so following check is necessary
+                if (((IExpandable)parent).getSubItems().contains(item))
+                    return new Pair<>(parent, parentIndex);
+                else
+                    return null;
+            }
+            parentIndex--;
+        }
+        return null;
+    }
+
+    /**
+     * deletes all selected items from the adapter respecting if the are sub items or not
+     * subitems are removed from their parents sublists, main items are directly removed
+     *
+     * @param deleteEmptyHeaders      if true, empty headers will be removed from the adapter
+     * @return List of items that have been removed from the adapter
+     */
+    public static List<IItem> deleteSelected(final FastItemAdapter adapter, boolean notifyParent, boolean deleteEmptyHeaders) {
+        List<IItem> deleted = new ArrayList<>();
+
+        // we use a LinkedList, because this has performance advantages when modifying the listIterator during iteration!
+        // Modifying list is O(1)
+        LinkedList<IItem> selectedItems = new LinkedList<>(adapter.getSelectedItems());
+
+        // we delete item per item from the adapter directly or from the parent
+        // if keepEmptyHeaders is false, we add empty headers to the selected items set via the iterator, so that they are processed in the loop as well
+        IItem item, parent;
+        int pos, parentIndex;
+        boolean expanded;
+        ListIterator<IItem> it = selectedItems.listIterator();
+        while(it.hasNext()){
+            item = it.next();
+            pos = adapter.getPosition(item);
+
+            // search for parent - if we find one, we remove the item from the parent's subitems directly
+            Pair<IItem, Integer> parentData = getParent(adapter, item, pos);
+            if (parentData != null) {
+                ((IExpandable)parentData.first).getSubItems().remove(item);
+                adapter.notifyAdapterSubItemsChanged(parentData.second, ((IExpandable)parentData.first).getSubItems().size() + 1);
+                if (notifyParent) {
+                    expanded = ((IExpandable)parentData.first).isExpanded();
+                    adapter.notifyAdapterItemChanged(parentData.second);
+                    // expand the item again if it was expanded before calling notifyAdapterItemChanged
+                    if (expanded)
+                        adapter.expand(parentData.second);
+                }
+
+                deleted.add(item);
+
+                if (deleteEmptyHeaders && ((IExpandable)parentData.first).getSubItems().size() == 0) {
+                    it.add(parentData.first);
+                    it.previous();
+                }
+            } else {
+                // if we did not find a parent, we remove the item from the adapter
+                adapter.remove(pos);
+                deleted.add(item);
+            }
+        }
+
+        return deleted;
+    }
+}

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/SubItemUtils.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/SubItemUtils.java
@@ -63,7 +63,7 @@ public class SubItemUtils {
      * @return number of items in the adapter that apply to the predicate
      */
     public static int countItems(final FastItemAdapter adapter, IPredicate predicate) {
-        return countItems(adapter, adapter.getAdapterItems(), true, false, predicate);
+        return countItems(adapter.getAdapterItems(), true, false, predicate);
     }
 
     /**
@@ -74,10 +74,10 @@ public class SubItemUtils {
      * @return number of items in the adapter
      */
     public static int countItems(final FastItemAdapter adapter, boolean countHeaders) {
-        return countItems(adapter, adapter.getAdapterItems(), countHeaders, false, null);
+        return countItems(adapter.getAdapterItems(), countHeaders, false, null);
     }
 
-    private static int countItems(final FastItemAdapter adapter, List<IItem> items, boolean countHeaders, boolean subItemsOnly, IPredicate predicate) {
+    private static int countItems(List<IItem> items, boolean countHeaders, boolean subItemsOnly, IPredicate predicate) {
         if (items == null || items.size() == 0)
             return 0;
 
@@ -91,7 +91,7 @@ public class SubItemUtils {
                 subItems = ((IExpandable)item).getSubItems();
                 if (predicate == null) {
                     count += subItems != null ? subItems.size() : 0;
-                    count += countItems(adapter, subItems, countHeaders, true, predicate);
+                    count += countItems(subItems, countHeaders, true, predicate);
                     if (countHeaders)
                         count++;
                 } else {
@@ -125,15 +125,19 @@ public class SubItemUtils {
      * @return number of selected items underneath the header
      */
     public static <T extends IItem & IExpandable> int countSelectedSubItems(final FastItemAdapter adapter, T header) {
+        Set<IItem> selections = getSelectedItems(adapter);
+        return countSelectedSubItems(selections, header);
+    }
+
+    public static <T extends IItem & IExpandable> int countSelectedSubItems(Set<IItem> selections, T header) {
         int count = 0;
-        Set<Integer> selections = adapter.getSelections();
-        int headerIndex = adapter.getPosition(header);
+        List<IItem> subItems = header.getSubItems();
         int items = header.getSubItems() != null ? header.getSubItems().size() : 0;
         for (int i = 0; i < items; i++) {
-            if (selections.contains(headerIndex + 1 + i))
+            if (selections.contains(subItems.get(i)))
                 count++;
-            if (header.getSubItems().get(i) instanceof IExpandable &&  ((IExpandable)header.getSubItems().get(i)).getSubItems() != null)
-                count += countSelectedSubItems(adapter, (T)header.getSubItems().get(i));
+            if (subItems.get(i) instanceof IExpandable &&  ((IExpandable)subItems.get(i)).getSubItems() != null)
+                count += countSelectedSubItems(selections, (T)subItems.get(i));
         }
         return count;
     }

--- a/library/src/main/java/com/mikepenz/fastadapter/AbstractAdapter.java
+++ b/library/src/main/java/com/mikepenz/fastadapter/AbstractAdapter.java
@@ -243,4 +243,11 @@ public abstract class AbstractAdapter<Item extends IItem> extends RecyclerView.A
     public void mapPossibleType(Item item) {
         mFastAdapter.registerTypeInstance(item);
     }
+
+    /**
+     * clears the internal mapper - be sure, to remap everything before going on
+     */
+    public void clearMappedTypes() {
+        mFastAdapter.clearTypeInstance();
+    }
 }

--- a/library/src/main/java/com/mikepenz/fastadapter/FastAdapter.java
+++ b/library/src/main/java/com/mikepenz/fastadapter/FastAdapter.java
@@ -388,6 +388,13 @@ public class FastAdapter<Item extends IItem> extends RecyclerView.Adapter<Recycl
     }
 
     /**
+     * clears the internal mapper - be sure, to remap everything before going on
+     */
+    public void clearTypeInstance() {
+       mTypeInstances.clear();
+    }
+
+    /**
      * helper method to get the position from a holder
      * overwrite this if you have an adapter adding additional items inbetwean
      *

--- a/library/src/main/java/com/mikepenz/fastadapter/IExpandable.java
+++ b/library/src/main/java/com/mikepenz/fastadapter/IExpandable.java
@@ -5,7 +5,7 @@ import java.util.List;
 /**
  * Created by mikepenz on 30.12.15.
  */
-public interface IExpandable<T, Item extends IItem> {
+public interface IExpandable<T, Item extends IItem & ISubItem> {
     /**
      * @return true if expanded (opened)
      */

--- a/library/src/main/java/com/mikepenz/fastadapter/IItemAdapter.java
+++ b/library/src/main/java/com/mikepenz/fastadapter/IItemAdapter.java
@@ -14,7 +14,7 @@ public interface IItemAdapter<Item extends IItem> extends IAdapter<Item> {
      * @param subItems    the subItems for this collapsible item
      * @return the item type of the collapsible
      */
-    <T> T setSubItems(IExpandable<T, Item> collapsible, List<Item> subItems);
+    <T extends IItem &IExpandable<T, S>, S extends IItem & ISubItem<Item, T>> T setSubItems(T collapsible, List<S> subItems);
 
     /**
      * set a new list of items and apply it to the existing list (clear - add) for this adapter

--- a/library/src/main/java/com/mikepenz/fastadapter/ISelectionListener.java
+++ b/library/src/main/java/com/mikepenz/fastadapter/ISelectionListener.java
@@ -1,0 +1,15 @@
+package com.mikepenz.fastadapter;
+
+/**
+ * Created by flisar on 21.09.2016.
+ */
+
+public interface ISelectionListener {
+    /**
+     * is called, whenever the provided item is selected or deselected
+     *
+     * @param item the item who's selection state changed
+     * param selected the new selection state of the item
+     */
+    void onSelectionChanged(IItem item, boolean selected);
+}

--- a/library/src/main/java/com/mikepenz/fastadapter/ISubItem.java
+++ b/library/src/main/java/com/mikepenz/fastadapter/ISubItem.java
@@ -1,0 +1,25 @@
+package com.mikepenz.fastadapter;
+
+import java.util.List;
+
+/**
+ * Created by mikepenz on 30.12.15.
+ */
+public interface ISubItem<T, S extends IItem & IExpandable>
+{
+    /**
+     * use this method to get the parent of this sub item
+     * the parent should also contain this sub item in it's sub items list
+     *
+     * @return the parent of this sub item
+     */
+    S getParent();
+
+    /**
+     * use this method to set the parent of this sub item
+     * make sure, that you add this item to the parents sub items list as well
+     *
+     * @param parent the parent of this sub item
+     */
+    T withParent(S parent);
+}

--- a/library/src/main/java/com/mikepenz/fastadapter/adapters/FastItemAdapter.java
+++ b/library/src/main/java/com/mikepenz/fastadapter/adapters/FastItemAdapter.java
@@ -282,4 +282,11 @@ public class FastItemAdapter<Item extends IItem> extends FastAdapter<Item> {
         mItemAdapter.clear();
         return this;
     }
+
+    /**
+     * convenient functions, to force to remap all possible types for the RecyclerView
+     */
+    public void remapMappedTypes() {
+        mItemAdapter.remapMappedTypes();
+    }
 }

--- a/library/src/main/java/com/mikepenz/fastadapter/adapters/FastItemAdapter.java
+++ b/library/src/main/java/com/mikepenz/fastadapter/adapters/FastItemAdapter.java
@@ -6,6 +6,7 @@ import com.mikepenz.fastadapter.FastAdapter;
 import com.mikepenz.fastadapter.IExpandable;
 import com.mikepenz.fastadapter.IItem;
 import com.mikepenz.fastadapter.IItemAdapter;
+import com.mikepenz.fastadapter.ISubItem;
 import com.mikepenz.fastadapter.utils.DiffCallback;
 
 import java.util.List;
@@ -128,7 +129,7 @@ public class FastItemAdapter<Item extends IItem> extends FastAdapter<Item> {
      * @param subItems    the subItems for this collapsible item
      * @return the item type of the collapsible
      */
-    public <T> T setSubItems(IExpandable<T, Item> collapsible, List<Item> subItems) {
+    public <T extends IItem &IExpandable<T, S>, S extends IItem & ISubItem<Item, T>> T setSubItems(T collapsible, List<S> subItems) {
         return mItemAdapter.setSubItems(collapsible, subItems);
     }
 

--- a/library/src/main/java/com/mikepenz/fastadapter/adapters/ItemAdapter.java
+++ b/library/src/main/java/com/mikepenz/fastadapter/adapters/ItemAdapter.java
@@ -400,6 +400,14 @@ public class ItemAdapter<Item extends IItem> extends AbstractAdapter<Item> imple
     }
 
     /**
+     * forces to remap all possible types for the RecyclerView
+     */
+    public void remapMappedTypes() {
+        clearMappedTypes();
+        mapPossibleTypes(mItems);
+    }
+
+    /**
      * add an array of items to the end of the existing items
      *
      * @param items the items to add

--- a/library/src/main/java/com/mikepenz/fastadapter/adapters/ItemAdapter.java
+++ b/library/src/main/java/com/mikepenz/fastadapter/adapters/ItemAdapter.java
@@ -9,6 +9,7 @@ import com.mikepenz.fastadapter.AbstractAdapter;
 import com.mikepenz.fastadapter.IExpandable;
 import com.mikepenz.fastadapter.IItem;
 import com.mikepenz.fastadapter.IItemAdapter;
+import com.mikepenz.fastadapter.ISubItem;
 import com.mikepenz.fastadapter.utils.DiffCallback;
 import com.mikepenz.fastadapter.utils.IdDistributor;
 
@@ -223,7 +224,7 @@ public class ItemAdapter<Item extends IItem> extends AbstractAdapter<Item> imple
      * @param subItems    the subItems for this collapsible item
      * @return the item type of the collapsible
      */
-    public <T> T setSubItems(IExpandable<T, Item> collapsible, List<Item> subItems) {
+    public <T extends IItem &IExpandable<T, S>, S extends IItem & ISubItem<Item, T>> T setSubItems(T collapsible, List<S> subItems) {
         if (mUseIdDistributor) {
             IdDistributor.checkIds(subItems);
         }

--- a/library/src/test/java/com/mikepenz/fastadapter/TestItem.java
+++ b/library/src/test/java/com/mikepenz/fastadapter/TestItem.java
@@ -10,9 +10,10 @@ import java.util.List;
 /**
  * Created by fabianterhorst on 29.03.16.
  */
-public class TestItem extends AbstractItem<TestItem, TestItem.ViewHolder> implements IExpandable<TestItem, TestItem> {
+public class TestItem extends AbstractItem<TestItem, TestItem.ViewHolder> implements IExpandable<TestItem, TestItem>, ISubItem<TestItem, TestItem> {
 
     private List<TestItem> mSubItems;
+    private TestItem mParent;
     private boolean mExpanded = false;
 
     @Override
@@ -48,6 +49,17 @@ public class TestItem extends AbstractItem<TestItem, TestItem.ViewHolder> implem
 
     public TestItem withSubItems(List<TestItem> subItems) {
         this.mSubItems = subItems;
+        return this;
+    }
+
+    @Override
+    public TestItem getParent() {
+        return mParent;
+    }
+
+    @Override
+    public TestItem withParent(TestItem parent) {
+        this.mParent = parent;
         return this;
     }
 


### PR DESCRIPTION
Following was added:

**SubItems**
* `SubItemUtils` (count, selection, delete functions that respect collapsed sub items)
* Demo activity added that shows those new functions in action
* Adjusted other examples to fulfill the new two way relation between `IExpandable` and `ISubItem`

**Others**
* `RangeSelectorHelper` - it tracks long pressed items and allows to select all items between the two consecutive long pressed items
* added ability to reset and recreate the map of all possible types for the `RecyclerView` (necessary, if don't want to change your items but you have items that are able to render different item types depending on a user selected theme for example)
* `ISelectionListener` - this allows to be notified about selection changes (regardless of where they come from!)