### PR TITLE
new EndlessRecyclerOnTopScrollListener

### DIFF
--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessRecyclerOnTopScrollListener.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessRecyclerOnTopScrollListener.java
@@ -19,11 +19,16 @@ public abstract class EndlessRecyclerOnTopScrollListener extends RecyclerView.On
     private int mFirstVisibleItem, mVisibleItemCount, mTotalItemCount;
     private boolean mAlreadyCalledOnNoMore;
     // how many items your adapter must have at the end?
+    // leave it -1 as it's by default to disable onNoMore() feature if you have only local data
     private int mTotalItems = -1;
 
     public EndlessRecyclerOnTopScrollListener(FastItemAdapter adapter, int totalItems) {
         this.mAdapter = adapter;
         mTotalItems = totalItems;
+    }
+
+    public EndlessRecyclerOnTopScrollListener(FastItemAdapter adapter) {
+        this.mAdapter = adapter;
     }
 
     public int getVisibleThreshold() {
@@ -68,7 +73,7 @@ public abstract class EndlessRecyclerOnTopScrollListener extends RecyclerView.On
 
             mLoading = true;
         } else {
-            if (mAdapter.getAdapterItemCount() == mTotalItems && !mAlreadyCalledOnNoMore) {
+            if (isOnNoMoreFeatureEnabled() && mAdapter.getAdapterItemCount() == mTotalItems && !mAlreadyCalledOnNoMore) {
                 onNoMore(this);
                 mAlreadyCalledOnNoMore = true;
             }
@@ -92,6 +97,10 @@ public abstract class EndlessRecyclerOnTopScrollListener extends RecyclerView.On
      * @param page     page number, starts from 0
      */
     public abstract void onLoadMore(EndlessRecyclerOnTopScrollListener listener, int page);
+
+    public boolean isOnNoMoreFeatureEnabled() {
+        return mTotalItems != -1;
+    }
 
     /**
      * there's no more data to be loaded, you may want

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessRecyclerOnTopScrollListener.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessRecyclerOnTopScrollListener.java
@@ -1,0 +1,195 @@
+package com.mikepenz.fastadapter_extensions.scroll;
+
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.OrientationHelper;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+
+import com.mikepenz.fastadapter.adapters.FastItemAdapter;
+
+public abstract class EndlessRecyclerOnTopScrollListener extends RecyclerView.OnScrollListener {
+    private int mPreviousTotal = 0;
+    private boolean mLoading = true;
+    private int mCurrentPage = 0;
+    private FastItemAdapter mAdapter;
+    private LinearLayoutManager mLayoutManager;
+    private int mVisibleThreshold = -1;
+    private OrientationHelper mOrientationHelper;
+    private boolean mIsOrientationHelperVertical;
+    private int mFirstVisibleItem, mVisibleItemCount, mTotalItemCount;
+    private boolean mAlreadyCalledOnNoMore;
+    // total loaded items in adapter will be changed automatically
+    private int mTotalLoadedItems = -1;
+    private RecyclerView.AdapterDataObserver mAdapterDataObserver = new RecyclerView.AdapterDataObserver() {
+        @Override
+        public void onChanged() {
+            super.onChanged();
+            mTotalLoadedItems = mAdapter.getAdapterItemCount();
+        }
+    };
+
+    public EndlessRecyclerOnTopScrollListener(FastItemAdapter adapter) {
+        this.mAdapter = adapter;
+        adapter.registerAdapterDataObserver(mAdapterDataObserver);
+    }
+
+    public int getVisibleThreshold() {
+        return mVisibleThreshold;
+    }
+
+    public void setVisibleThreshold(int visibleThreshold) {
+        this.mVisibleThreshold = visibleThreshold;
+    }
+
+    /**
+     * unregister automatically created adapter data observer
+     */
+    public void unregisterAdapterDataObserver() {
+        mAdapter.unregisterAdapterDataObserver(mAdapterDataObserver);
+    }
+
+    public int getTotalLoadedItems() {
+        return mTotalLoadedItems;
+    }
+
+    public void setTotalLoadedItems(int totalLoadedItems) {
+        this.mTotalLoadedItems = totalLoadedItems;
+    }
+
+    public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
+        super.onScrolled(recyclerView, dx, dy);
+        if (this.mLayoutManager == null) {
+            this.mLayoutManager = (LinearLayoutManager) recyclerView.getLayoutManager();
+        }
+
+        if (mVisibleThreshold == -1) {
+            mVisibleThreshold = findLastVisibleItemPosition(recyclerView) - findFirstVisibleItemPosition(recyclerView);
+        }
+
+        mVisibleItemCount = recyclerView.getChildCount();
+        mTotalItemCount = mLayoutManager.getItemCount();
+        mFirstVisibleItem = findFirstVisibleItemPosition(recyclerView);
+
+        mTotalItemCount = mAdapter.getItemCount();
+
+        if (mLoading) {
+            if (mTotalItemCount > mPreviousTotal) {
+                mLoading = false;
+                mPreviousTotal = mTotalItemCount;
+            }
+        }
+
+        if (!mLoading && mLayoutManager.findFirstVisibleItemPosition() - mVisibleThreshold <= 0) {
+            mCurrentPage++;
+
+            onLoadMore(this, mCurrentPage);
+
+            mLoading = true;
+        } else {
+            if (mAdapter.getAdapterItemCount() == mTotalLoadedItems && !mAlreadyCalledOnNoMore) {
+                onNoMore(this);
+                mAlreadyCalledOnNoMore = true;
+            }
+        }
+    }
+
+    private int findLastVisibleItemPosition(RecyclerView recyclerView) {
+        final View child = findOneVisibleChild(recyclerView.getChildCount() - 1, -1, false, true);
+        return child == null ? RecyclerView.NO_POSITION : recyclerView.getChildAdapterPosition(child);
+    }
+
+    private int findFirstVisibleItemPosition(RecyclerView recyclerView) {
+        final View child = findOneVisibleChild(0, mLayoutManager.getChildCount(), false, true);
+        return child == null ? RecyclerView.NO_POSITION : recyclerView.getChildAdapterPosition(child);
+    }
+
+    /**
+     * load more data
+     *
+     * @param listener this
+     * @param page     page number, starts from 0
+     */
+    public abstract void onLoadMore(EndlessRecyclerOnTopScrollListener listener, int page);
+
+    /**
+     * there's no more data to be loaded, you may want
+     * to send a request to server for asking more data
+     *
+     * @param listener this
+     */
+    public abstract void onNoMore(EndlessRecyclerOnTopScrollListener listener);
+
+    private View findOneVisibleChild(int fromIndex, int toIndex, boolean completelyVisible,
+                                     boolean acceptPartiallyVisible) {
+        if (mLayoutManager.canScrollVertically() != mIsOrientationHelperVertical
+                || mOrientationHelper == null) {
+            mIsOrientationHelperVertical = mLayoutManager.canScrollVertically();
+            mOrientationHelper = mIsOrientationHelperVertical
+                    ? OrientationHelper.createVerticalHelper(mLayoutManager)
+                    : OrientationHelper.createHorizontalHelper(mLayoutManager);
+        }
+
+        final int start = mOrientationHelper.getStartAfterPadding();
+        final int end = mOrientationHelper.getEndAfterPadding();
+        final int next = toIndex > fromIndex ? 1 : -1;
+        View partiallyVisible = null;
+        for (int i = fromIndex; i != toIndex; i += next) {
+            final View child = mLayoutManager.getChildAt(i);
+            if (child != null) {
+                final int childStart = mOrientationHelper.getDecoratedStart(child);
+                final int childEnd = mOrientationHelper.getDecoratedEnd(child);
+                if (childStart < end && childEnd > start) {
+                    if (completelyVisible) {
+                        if (childStart >= start && childEnd <= end) {
+                            return child;
+                        } else if (acceptPartiallyVisible && partiallyVisible == null) {
+                            partiallyVisible = child;
+                        }
+                    } else {
+                        return child;
+                    }
+                }
+            }
+        }
+        return partiallyVisible;
+    }
+
+    /**
+     * reset page count
+     */
+    public void resetPageCount() {
+        this.resetPageCount(0);
+    }
+
+    /**
+     * reset page count to specified page
+     *
+     * @param page page number, starts from 0
+     */
+    public void resetPageCount(int page) {
+        this.mPreviousTotal = 0;
+        this.mLoading = true;
+        this.mCurrentPage = page;
+        this.onLoadMore(this, this.mCurrentPage);
+    }
+
+    public RecyclerView.LayoutManager getLayoutManager() {
+        return mLayoutManager;
+    }
+
+    public int getTotalItemCount() {
+        return mTotalItemCount;
+    }
+
+    public int getFirstVisibleItem() {
+        return mFirstVisibleItem;
+    }
+
+    public int getVisibleItemCount() {
+        return mVisibleItemCount;
+    }
+
+    public int getCurrentPage() {
+        return mCurrentPage;
+    }
+}

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessRecyclerOnTopScrollListener.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessRecyclerOnTopScrollListener.java
@@ -69,12 +69,12 @@ public abstract class EndlessRecyclerOnTopScrollListener extends RecyclerView.On
         if (!mLoading && mLayoutManager.findFirstVisibleItemPosition() - mVisibleThreshold <= 0) {
             mCurrentPage++;
 
-            onLoadMore(this, mCurrentPage);
+            onLoadMore(mCurrentPage);
 
             mLoading = true;
         } else {
-            if (isOnNoMoreFeatureEnabled() && mAdapter.getAdapterItemCount() == mTotalItems && !mAlreadyCalledOnNoMore) {
-                onNoMore(this);
+            if (isOnNoMoreFeatureEnabled() && needNoMore()) {
+                onNoMore();
                 mAlreadyCalledOnNoMore = true;
             }
         }
@@ -93,22 +93,23 @@ public abstract class EndlessRecyclerOnTopScrollListener extends RecyclerView.On
     /**
      * load more data
      *
-     * @param listener this
-     * @param page     page number, starts from 0
+     * @param page page number, starts from 0
      */
-    public abstract void onLoadMore(EndlessRecyclerOnTopScrollListener listener, int page);
+    public abstract void onLoadMore(int page);
 
     public boolean isOnNoMoreFeatureEnabled() {
         return mTotalItems != -1;
     }
 
+    private boolean needNoMore() {
+        return mAdapter.getAdapterItemCount() == mTotalItems && !mAlreadyCalledOnNoMore;
+    }
+
     /**
      * there's no more data to be loaded, you may want
      * to send a request to server for asking more data
-     *
-     * @param listener this
-     */
-    public abstract void onNoMore(EndlessRecyclerOnTopScrollListener listener);
+     **/
+    public abstract void onNoMore();
 
     private View findOneVisibleChild(int fromIndex, int toIndex, boolean completelyVisible,
                                      boolean acceptPartiallyVisible) {
@@ -161,7 +162,7 @@ public abstract class EndlessRecyclerOnTopScrollListener extends RecyclerView.On
         this.mPreviousTotal = 0;
         this.mLoading = true;
         this.mCurrentPage = page;
-        this.onLoadMore(this, this.mCurrentPage);
+        this.onLoadMore(this.mCurrentPage);
     }
 
     public RecyclerView.LayoutManager getLayoutManager() {

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessRecyclerOnTopScrollListener.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessRecyclerOnTopScrollListener.java
@@ -18,19 +18,12 @@ public abstract class EndlessRecyclerOnTopScrollListener extends RecyclerView.On
     private boolean mIsOrientationHelperVertical;
     private int mFirstVisibleItem, mVisibleItemCount, mTotalItemCount;
     private boolean mAlreadyCalledOnNoMore;
-    // total loaded items in adapter will be changed automatically
-    private int mTotalLoadedItems = -1;
-    private RecyclerView.AdapterDataObserver mAdapterDataObserver = new RecyclerView.AdapterDataObserver() {
-        @Override
-        public void onChanged() {
-            super.onChanged();
-            mTotalLoadedItems = mAdapter.getAdapterItemCount();
-        }
-    };
+    // how many items your adapter must have at the end?
+    private int mTotalItems = -1;
 
-    public EndlessRecyclerOnTopScrollListener(FastItemAdapter adapter) {
+    public EndlessRecyclerOnTopScrollListener(FastItemAdapter adapter, int totalItems) {
         this.mAdapter = adapter;
-        adapter.registerAdapterDataObserver(mAdapterDataObserver);
+        mTotalItems = totalItems;
     }
 
     public int getVisibleThreshold() {
@@ -41,19 +34,8 @@ public abstract class EndlessRecyclerOnTopScrollListener extends RecyclerView.On
         this.mVisibleThreshold = visibleThreshold;
     }
 
-    /**
-     * unregister automatically created adapter data observer
-     */
-    public void unregisterAdapterDataObserver() {
-        mAdapter.unregisterAdapterDataObserver(mAdapterDataObserver);
-    }
-
     public int getTotalLoadedItems() {
-        return mTotalLoadedItems;
-    }
-
-    public void setTotalLoadedItems(int totalLoadedItems) {
-        this.mTotalLoadedItems = totalLoadedItems;
+        return mTotalItems;
     }
 
     public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
@@ -86,7 +68,7 @@ public abstract class EndlessRecyclerOnTopScrollListener extends RecyclerView.On
 
             mLoading = true;
         } else {
-            if (mAdapter.getAdapterItemCount() == mTotalLoadedItems && !mAlreadyCalledOnNoMore) {
+            if (mAdapter.getAdapterItemCount() == mTotalItems && !mAlreadyCalledOnNoMore) {
                 onNoMore(this);
                 mAlreadyCalledOnNoMore = true;
             }

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessRecyclerOnTopScrollListener.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/scroll/EndlessRecyclerOnTopScrollListener.java
@@ -5,13 +5,13 @@ import android.support.v7.widget.OrientationHelper;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 
-import com.mikepenz.fastadapter.adapters.FastItemAdapter;
+import com.mikepenz.fastadapter.FastAdapter;
 
 public abstract class EndlessRecyclerOnTopScrollListener extends RecyclerView.OnScrollListener {
     private int mPreviousTotal = 0;
     private boolean mLoading = true;
     private int mCurrentPage = 0;
-    private FastItemAdapter mAdapter;
+    private FastAdapter mAdapter;
     private LinearLayoutManager mLayoutManager;
     private int mVisibleThreshold = -1;
     private OrientationHelper mOrientationHelper;
@@ -19,15 +19,15 @@ public abstract class EndlessRecyclerOnTopScrollListener extends RecyclerView.On
     private int mFirstVisibleItem, mVisibleItemCount, mTotalItemCount;
     private boolean mAlreadyCalledOnNoMore;
     // how many items your adapter must have at the end?
-    // leave it -1 as it's by default to disable onNoMore() feature if you have only local data
+    // leave it -1 as it's by default to disable onNothingToLoad() feature if you have only local data
     private int mTotalItems = -1;
 
-    public EndlessRecyclerOnTopScrollListener(FastItemAdapter adapter, int totalItems) {
+    public EndlessRecyclerOnTopScrollListener(FastAdapter adapter, int totalItems) {
         this.mAdapter = adapter;
         mTotalItems = totalItems;
     }
 
-    public EndlessRecyclerOnTopScrollListener(FastItemAdapter adapter) {
+    public EndlessRecyclerOnTopScrollListener(FastAdapter adapter) {
         this.mAdapter = adapter;
     }
 
@@ -73,8 +73,8 @@ public abstract class EndlessRecyclerOnTopScrollListener extends RecyclerView.On
 
             mLoading = true;
         } else {
-            if (isOnNoMoreFeatureEnabled() && needNoMore()) {
-                onNoMore();
+            if (isNothingToLoadFeatureEnabled() && isNothingToLoadNeeded()) {
+                onNothingToLoad();
                 mAlreadyCalledOnNoMore = true;
             }
         }
@@ -97,19 +97,19 @@ public abstract class EndlessRecyclerOnTopScrollListener extends RecyclerView.On
      */
     public abstract void onLoadMore(int page);
 
-    public boolean isOnNoMoreFeatureEnabled() {
+    public boolean isNothingToLoadFeatureEnabled() {
         return mTotalItems != -1;
     }
 
-    private boolean needNoMore() {
-        return mAdapter.getAdapterItemCount() == mTotalItems && !mAlreadyCalledOnNoMore;
+    private boolean isNothingToLoadNeeded() {
+        return mAdapter.getItemCount() == mTotalItems && !mAlreadyCalledOnNoMore;
     }
 
     /**
      * there's no more data to be loaded, you may want
      * to send a request to server for asking more data
      **/
-    public abstract void onNoMore();
+    public abstract void onNothingToLoad();
 
     private View findOneVisibleChild(int fromIndex, int toIndex, boolean completelyVisible,
                                      boolean acceptPartiallyVisible) {


### PR DESCRIPTION
Hi Mike,

With this `EndlessRecyclerOnTopScrollListener` users may load more data while scrolling top on their `RecyclerView`s.

**Features**
- Automatically finding good visible threshold
- `onLoadMore()` when need to load more data
- `onNoMore()` when there's no data to be loaded, user may wants to send a request to the server for asking more data (not required for loading data from local DB)

**Sample**
```java
RecyclerView rv = (RecyclerView) findViewById(R.id.rv);
LinearLayoutManager layoutManager = new LinearLayoutManager(getApplicationContext());
final FastItemAdapter<SampleItem> adapter = new FastItemAdapter<>();

rv.setHasFixedSize(true);
layoutManager.setStackFromEnd(true);
rv.setLayoutManager(layoutManager);
rv.setAdapter(adapter);

for (int i = 0; i < 100; i++) {
	adapter.add(new SampleItem().setName("default loaded data > " + i));
}

rv.addOnScrollListener(new EndlessRecyclerOnTopScrollListener(adapter, 190) {
	@Override
	public void onLoadMore(final int page) {
		if (page == 10) {
			return;
		}
		new Handler().postDelayed(new Runnable() {
			@Override
			public void run() {
				for (int i = 0; i < 10; i++) {
					// add new data to position 0
					adapter.add(0, new SampleItem().setName("loaded from local, page " + page + " > " + i));
				}
			}
		}, 1000);
	}

	@Override
	public void onNoMore() {
		Log.i(SampleActivity.class.getSimpleName(), "load data from server");
	}
});
```