### PR TITLE
Drag&Drop improved

### DIFF
--- a/library/src/main/java/com/mikepenz/fastadapter/IExtendedDraggable.java
+++ b/library/src/main/java/com/mikepenz/fastadapter/IExtendedDraggable.java
@@ -1,0 +1,37 @@
+package com.mikepenz.fastadapter;
+
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.helper.ItemTouchHelper;
+import android.view.View;
+
+/**
+ * Created by mikepenz on 30.12.15.
+ */
+public interface IExtendedDraggable<T, VH extends RecyclerView.ViewHolder, Item extends IItem> extends IDraggable<T, Item> {
+
+    /**
+     * use this method to set the ItemTouchHelper reference in the item
+     * this is necessary, so that the item can manually start the dragging
+     * i.e when a drag icon within the item is touched
+     *
+     * @param itemTouchHelper the ItemTouchHelper
+     * @return this
+     */
+    T withTouchHelper(ItemTouchHelper itemTouchHelper);
+
+    /**
+     * this returns the ItemTouchHelper
+     *
+     * @return the ItemTouchHelper if item has one or null
+     */
+    ItemTouchHelper getTouchHelper();
+
+    /**
+     * this method returns the drag view inside the item
+     * use this with (@withTouchHelper) to start dragging when this view is touched
+     *
+     * @param viewHolder the ViewHolder
+     * @return the view that should start the dragging or null
+     */
+    View getDragView(VH viewHolder);
+}

--- a/library/src/main/java/com/mikepenz/fastadapter/items/AbstractItem.java
+++ b/library/src/main/java/com/mikepenz/fastadapter/items/AbstractItem.java
@@ -190,7 +190,7 @@ public abstract class AbstractItem<Item extends IItem & IClickable, VH extends R
         holder.itemView.setSelected(isSelected());
         //set the tag of this item to this object (can be used when retrieving the view)
         holder.itemView.setTag(this);
-        // if necessry, init the drag handle, which will start the drag when touched
+        // if necessary, init the drag handle, which will start the drag when touched
         if (this instanceof IExtendedDraggable && ((IExtendedDraggable)this).getTouchHelper() != null && ((IExtendedDraggable)this).getDragView(holder) != null) {
             ((IExtendedDraggable)this).getDragView(holder).setOnTouchListener(new View.OnTouchListener() {
                 @Override

--- a/library/src/main/java/com/mikepenz/fastadapter/items/AbstractItem.java
+++ b/library/src/main/java/com/mikepenz/fastadapter/items/AbstractItem.java
@@ -2,13 +2,16 @@ package com.mikepenz.fastadapter.items;
 
 import android.content.Context;
 import android.support.annotation.CallSuper;
+import android.support.v4.view.MotionEventCompat;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 
 import com.mikepenz.fastadapter.FastAdapter;
 import com.mikepenz.fastadapter.IClickable;
+import com.mikepenz.fastadapter.IExtendedDraggable;
 import com.mikepenz.fastadapter.IItem;
 import com.mikepenz.fastadapter.utils.ViewHolderFactory;
 
@@ -182,11 +185,25 @@ public abstract class AbstractItem<Item extends IItem & IClickable, VH extends R
 
     @Override
     @CallSuper
-    public void bindView(VH holder, List payloads) {
+    public void bindView(final VH holder, List payloads) {
         //set the selected state of this item. force this otherwise it may is missed when implementing an item
         holder.itemView.setSelected(isSelected());
         //set the tag of this item to this object (can be used when retrieving the view)
         holder.itemView.setTag(this);
+        // if necessry, init the drag handle, which will start the drag when touched
+        if (this instanceof IExtendedDraggable && ((IExtendedDraggable)this).getTouchHelper() != null && ((IExtendedDraggable)this).getDragView(holder) != null) {
+            ((IExtendedDraggable)this).getDragView(holder).setOnTouchListener(new View.OnTouchListener() {
+                @Override
+                public boolean onTouch(View v, MotionEvent event) {
+                    if (MotionEventCompat.getActionMasked(event) == MotionEvent.ACTION_DOWN) {
+                        if (((IExtendedDraggable)AbstractItem.this).isDraggable())
+                            ((IExtendedDraggable)AbstractItem.this).getTouchHelper().startDrag(holder);
+                    }
+                    return false;
+                }
+            });
+        }
+
     }
 
     @Override


### PR DESCRIPTION
Usage is like following:

* implement the new `IExtendedDraggable` interface in your item
* setup the `SimpleDragCallback` and disable the drag enabled (this disables the drag on long press, we don't want that, we want to let the item itself decide)
* pass the drag helper to the items

