### PR TITLE
added a notifier function for sub items

### DIFF
--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/SubItemUtil.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/SubItemUtil.java
@@ -340,15 +340,15 @@ public class SubItemUtil {
         if (identifiers.contains(header.getIdentifier()))
             adapter.notifyAdapterItemChanged(position);
         // 2) check sub items, recursively
-        List<IItem> items;
+        IItem item;
         if (header.isExpanded()) {
             for (int i = 0; i < subItems; i++) {
-                items = header.getSubItems();
-                if (identifiers.contains((items.get(i)).getIdentifier())) {
+                item = (IItem)header.getSubItems().get(i);
+                if (identifiers.contains(item.getIdentifier())) {
 //                    Log.d("NOTIFY", "Position=" + position + ", i=" + i);
                     adapter.notifyAdapterItemChanged(position + i + 1);
                 }
-                if (checkSubItems && items.get(i) instanceof IExpandable) {
+                if (checkSubItems && item instanceof IExpandable) {
                     notifyItemsChanged(adapter, header, identifiers, true);
                 }
             }

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/SubItemUtil.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/SubItemUtil.java
@@ -306,7 +306,7 @@ public class SubItemUtil {
     }
 
     /**
-     * notifies sub items, if they are currently extended
+     * notifies items (incl. sub items if they are currently extended)
      *
      * @param adapter the adapter
      * @param identifiers set of identifiers that should be notified
@@ -326,7 +326,7 @@ public class SubItemUtil {
     }
 
     /**
-     * notifies sub items, if they are currently extended
+     * notifies items (incl. sub items if they are currently extended)
      *
      * @param adapter the adapter
      * @param header the expandable header that should be checked (incl. sub items)

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/SubItemUtil.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/SubItemUtil.java
@@ -349,7 +349,7 @@ public class SubItemUtil {
                     adapter.notifyAdapterItemChanged(position + i + 1);
                 }
                 if (checkSubItems && item instanceof IExpandable) {
-                    notifyItemsChanged(adapter, header, identifiers, true);
+                    notifyItemsChanged(adapter, (Item)item, identifiers, true);
                 }
             }
         }

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/SubItemUtil.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/SubItemUtil.java
@@ -305,6 +305,54 @@ public class SubItemUtil {
         return deleted;
     }
 
+    /**
+     * notifies sub items, if they are currently extended
+     *
+     * @param adapter the adapter
+     * @param identifiers set of identifiers that should be notified
+     */
+    public static <T extends IItem & IExpandable> void notifyItemsChanged(final FastAdapter adapter, Set<Long> identifiers) {
+        int i;
+        IItem item;
+        for (i = 0; i < adapter.getItemCount(); i++) {
+            item = adapter.getItem(i);
+            if (item instanceof IExpandable) {
+                notifyItemsChanged(adapter, (T) item, identifiers, true);
+            }
+            else if (identifiers.contains(item.getIdentifier())) {
+                adapter.notifyAdapterItemChanged(i);
+            }
+        }
+    }
+
+    /**
+     * notifies sub items, if they are currently extended
+     *
+     * @param adapter the adapter
+     * @param header the expandable header that should be checked (incl. sub items)
+     * @param identifiers set of identifiers that should be notified
+     * @param checkSubItems true, if sub items of headers items should be checked recursively
+     */
+    public static <T extends IItem & IExpandable> void notifyItemsChanged(final FastAdapter adapter, T header, Set<Long> identifiers, boolean checkSubItems) {
+        int subItems = header.getSubItems().size();
+        int position = adapter.getPosition(header);
+        // 1) check header itself
+        if (identifiers.contains(header.getIdentifier()))
+            adapter.notifyAdapterItemChanged(position);
+        // 2) check sub items, recursively
+        if (header.isExpanded()) {
+            for (int i = 0; i < subItems; i++) {
+                if (identifiers.contains(((IItem)header.getSubItems().get(i)).getIdentifier())) {
+//                    Log.d("NOTIFY", "Position=" + position + ", i=" + i);
+                    adapter.notifyAdapterItemChanged(position + i + 1);
+                }
+                if (checkSubItems && header.getSubItems().get(i) instanceof IExpandable) {
+                    notifyItemsChanged(adapter, header, identifiers, true);
+                }
+            }
+        }
+    }
+
     public interface IPredicate<T> {
         boolean apply(T data);
     }

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/SubItemUtil.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/SubItemUtil.java
@@ -340,13 +340,15 @@ public class SubItemUtil {
         if (identifiers.contains(header.getIdentifier()))
             adapter.notifyAdapterItemChanged(position);
         // 2) check sub items, recursively
+        List<IItem> items;
         if (header.isExpanded()) {
             for (int i = 0; i < subItems; i++) {
-                if (identifiers.contains(((IItem)header.getSubItems().get(i)).getIdentifier())) {
+                items = header.getSubItems();
+                if (identifiers.contains((items.get(i)).getIdentifier())) {
 //                    Log.d("NOTIFY", "Position=" + position + ", i=" + i);
                     adapter.notifyAdapterItemChanged(position + i + 1);
                 }
-                if (checkSubItems && header.getSubItems().get(i) instanceof IExpandable) {
+                if (checkSubItems && items.get(i) instanceof IExpandable) {
                     notifyItemsChanged(adapter, header, identifiers, true);
                 }
             }

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/SubItemUtil.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/SubItemUtil.java
@@ -311,13 +311,13 @@ public class SubItemUtil {
      * @param adapter the adapter
      * @param identifiers set of identifiers that should be notified
      */
-    public static <T extends IItem & IExpandable> void notifyItemsChanged(final FastAdapter adapter, Set<Long> identifiers) {
+    public static <ITEM extends IItem & IExpandable> void notifyItemsChanged(final FastAdapter adapter, Set<Long> identifiers) {
         int i;
         IItem item;
         for (i = 0; i < adapter.getItemCount(); i++) {
             item = adapter.getItem(i);
             if (item instanceof IExpandable) {
-                notifyItemsChanged(adapter, (T) item, identifiers, true);
+                notifyItemsChanged(adapter, (ITEM) item, identifiers, true);
             }
             else if (identifiers.contains(item.getIdentifier())) {
                 adapter.notifyAdapterItemChanged(i);

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/SubItemUtil.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/SubItemUtil.java
@@ -311,13 +311,13 @@ public class SubItemUtil {
      * @param adapter the adapter
      * @param identifiers set of identifiers that should be notified
      */
-    public static <ITEM extends IItem & IExpandable> void notifyItemsChanged(final FastAdapter adapter, Set<Long> identifiers) {
+    public static <Item extends IItem & IExpandable> void notifyItemsChanged(final FastAdapter adapter, Set<Long> identifiers) {
         int i;
         IItem item;
         for (i = 0; i < adapter.getItemCount(); i++) {
             item = adapter.getItem(i);
             if (item instanceof IExpandable) {
-                notifyItemsChanged(adapter, (ITEM) item, identifiers, true);
+                notifyItemsChanged(adapter, (Item) item, identifiers, true);
             }
             else if (identifiers.contains(item.getIdentifier())) {
                 adapter.notifyAdapterItemChanged(i);
@@ -333,7 +333,7 @@ public class SubItemUtil {
      * @param identifiers set of identifiers that should be notified
      * @param checkSubItems true, if sub items of headers items should be checked recursively
      */
-    public static <T extends IItem & IExpandable> void notifyItemsChanged(final FastAdapter adapter, T header, Set<Long> identifiers, boolean checkSubItems) {
+    public static <Item extends IItem & IExpandable> void notifyItemsChanged(final FastAdapter adapter, Item header, Set<Long> identifiers, boolean checkSubItems) {
         int subItems = header.getSubItems().size();
         int position = adapter.getPosition(header);
         // 1) check header itself


### PR DESCRIPTION
* added a small function to notify the adapter about changed sub items via identifiers which will update the selected items directly and only if they are currently visible in the adapter

Additionally, I wanted to throw in following:

Nearly everywhere, you are not handling sub items in your default adapter implementations. Why do you have a `notifyAdapterSubItemsChanged`? I think this is a little confusing and should be part of the `SubItemUtil` as well...