### PR TITLE
Use more memory-efficient data structures in core FastAdapter

### DIFF
--- a/library-core/src/main/java/com/mikepenz/fastadapter/FastAdapter.java
+++ b/library-core/src/main/java/com/mikepenz/fastadapter/FastAdapter.java
@@ -2,9 +2,10 @@ package com.mikepenz.fastadapter;
 
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v4.util.ArrayMap;
+import android.support.v4.util.ArraySet;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
+import android.util.SparseArray;
 import android.util.SparseIntArray;
 import android.view.MotionEvent;
 import android.view.View;
@@ -19,16 +20,9 @@ import com.mikepenz.fastadapter.utils.AdapterUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
-import java.util.NavigableMap;
 import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeMap;
-import java.util.TreeSet;
 
 /**
  * Created by mikepenz on 27.12.15.
@@ -39,11 +33,11 @@ public class FastAdapter<Item extends IItem> extends RecyclerView.Adapter<Recycl
 
     // we remember all adapters
     //priority queue...
-    final private ArrayMap<Integer, IAdapter<Item>> mAdapters = new ArrayMap<>();
+    final private SparseArray<IAdapter<Item>> mAdapters = new SparseArray<>();
     // we remember all possible types so we can create a new view efficiently
-    final private ArrayMap<Integer, Item> mTypeInstances = new ArrayMap<>();
+    final private SparseArray<Item> mTypeInstances = new SparseArray<>();
     // cache the sizes of the different adapters so we can access the items more performant
-    final private NavigableMap<Integer, IAdapter<Item>> mAdapterSizes = new TreeMap<>();
+    final private SparseArray<IAdapter<Item>> mAdapterSizes = new SparseArray<>();
     // the total size
     private int mGlobalSize = 0;
 
@@ -67,7 +61,7 @@ public class FastAdapter<Item extends IItem> extends RecyclerView.Adapter<Recycl
     private boolean mLegacyBindViewMode = false;
 
     // we need to remember all selections to recreate them after orientation change
-    private SortedSet<Integer> mSelections = new TreeSet<>();
+    private Set<Integer> mSelections = new ArraySet<>();
     // we need to remember all expanded items to recreate them after orientation change
     private SparseIntArray mExpanded = new SparseIntArray();
 
@@ -86,6 +80,14 @@ public class FastAdapter<Item extends IItem> extends RecyclerView.Adapter<Recycl
     //the listeners for onCreateViewHolder or onBindViewHolder
     private OnCreateViewHolderListener mOnCreateViewHolderListener = new OnCreateViewHolderListenerImpl();
     private OnBindViewHolderListener mOnBindViewHolderListener = new OnBindViewHolderListenerImpl();
+
+    private static int floorIndex(SparseArray<?> sparseArray, int key) {
+        int index = sparseArray.indexOfKey(key);
+        if (index < 0) {
+            index = ~index - 1;
+        }
+        return index;
+    }
 
     /**
      * default CTOR
@@ -384,7 +386,7 @@ public class FastAdapter<Item extends IItem> extends RecyclerView.Adapter<Recycl
      * @param adapter an adapter which extends the AbstractAdapter
      */
     public <A extends AbstractAdapter<Item>> void registerAdapter(A adapter) {
-        if (!mAdapters.containsKey(adapter.getOrder())) {
+        if (mAdapters.indexOfKey(adapter.getOrder()) < 0) {
             mAdapters.put(adapter.getOrder(), adapter);
             cacheSizes();
         }
@@ -396,7 +398,7 @@ public class FastAdapter<Item extends IItem> extends RecyclerView.Adapter<Recycl
      * @param item an IItem which will be shown in the list
      */
     public void registerTypeInstance(Item item) {
-        if (!mTypeInstances.containsKey(item.getType())) {
+        if (mTypeInstances.indexOfKey(item.getType()) < 0) {
             mTypeInstances.put(item.getType(), item);
         }
     }
@@ -641,8 +643,8 @@ public class FastAdapter<Item extends IItem> extends RecyclerView.Adapter<Recycl
             return null;
         }
         //now get the adapter which is responsible for the given position
-        Map.Entry<Integer, IAdapter<Item>> entry = mAdapterSizes.floorEntry(position);
-        return entry.getValue().getAdapterItem(position - entry.getKey());
+        int index = floorIndex(mAdapterSizes, position);
+        return mAdapterSizes.valueAt(index).getAdapterItem(position - mAdapterSizes.keyAt(index));
     }
 
     /**
@@ -658,10 +660,10 @@ public class FastAdapter<Item extends IItem> extends RecyclerView.Adapter<Recycl
         }
 
         RelativeInfo<Item> relativeInfo = new RelativeInfo<>();
-        Map.Entry<Integer, IAdapter<Item>> entry = mAdapterSizes.floorEntry(position);
-        if (entry != null) {
-            relativeInfo.item = entry.getValue().getAdapterItem(position - entry.getKey());
-            relativeInfo.adapter = entry.getValue();
+        int index = floorIndex(mAdapterSizes, position);
+        if (index != -1) {
+            relativeInfo.item = mAdapterSizes.valueAt(index).getAdapterItem(position - mAdapterSizes.keyAt(index));
+            relativeInfo.adapter = mAdapterSizes.valueAt(index);
             relativeInfo.position = position;
         }
         return relativeInfo;
@@ -679,7 +681,7 @@ public class FastAdapter<Item extends IItem> extends RecyclerView.Adapter<Recycl
             return null;
         }
         //now get the adapter which is responsible for the given position
-        return mAdapterSizes.floorEntry(position).getValue();
+        return mAdapterSizes.valueAt(floorIndex(mAdapterSizes, position));
     }
 
     /**
@@ -728,7 +730,8 @@ public class FastAdapter<Item extends IItem> extends RecyclerView.Adapter<Recycl
         int size = 0;
 
         //count the number of items before the adapter with the given order
-        for (IAdapter<Item> adapter : mAdapters.values()) {
+        for (int i = 0, adapterSize = mAdapters.size(); i < adapterSize; i++) {
+            IAdapter<Item> adapter = mAdapters.valueAt(i);
             if (adapter.getOrder() == order) {
                 return size;
             } else {
@@ -754,7 +757,7 @@ public class FastAdapter<Item extends IItem> extends RecyclerView.Adapter<Recycl
         }
 
         //get the count of items which are before this order
-        return mAdapterSizes.floorKey(position);
+        return mAdapterSizes.keyAt(floorIndex(mAdapterSizes, position));
     }
 
     /**
@@ -863,17 +866,19 @@ public class FastAdapter<Item extends IItem> extends RecyclerView.Adapter<Recycl
         mAdapterSizes.clear();
         int size = 0;
 
-        //we also have to add this for the first adapter otherwise the floorKey method will return the wrong value
-        if (mAdapters.size() > 0) {
-            mAdapterSizes.put(0, mAdapters.valueAt(0));
-        }
-
-        for (IAdapter<Item> adapter : mAdapters.values()) {
+        for (int i = 0, adapterSize = mAdapters.size(); i < adapterSize; i++) {
+            IAdapter<Item> adapter = mAdapters.valueAt(i);
             if (adapter.getAdapterItemCount() > 0) {
-                mAdapterSizes.put(size, adapter);
+                mAdapterSizes.append(size, adapter);
                 size = size + adapter.getAdapterItemCount();
             }
         }
+
+        //we also have to add this for the first adapter otherwise the floorIndex method will return the wrong value
+        if (size == 0 && mAdapters.size() > 0) {
+            mAdapterSizes.append(0, mAdapters.valueAt(0));
+        }
+
         mGlobalSize = size;
     }
 
@@ -890,7 +895,7 @@ public class FastAdapter<Item extends IItem> extends RecyclerView.Adapter<Recycl
         if (mPositionBasedStateManagement) {
             return mSelections;
         } else {
-            Set<Integer> selections = new HashSet<>();
+            Set<Integer> selections = new ArraySet<>();
             Item item;
             for (int i = 0, size = getItemCount(); i < size; i++) {
                 item = getItem(i);
@@ -907,8 +912,9 @@ public class FastAdapter<Item extends IItem> extends RecyclerView.Adapter<Recycl
      * @return a set with the items which are currently selected
      */
     public Set<Item> getSelectedItems() {
-        Set<Item> items = new HashSet<>();
-        for (Integer position : getSelections()) {
+        Set<Integer> selections = getSelections();
+        Set<Item> items = new ArraySet<>(selections.size());
+        for (Integer position : selections) {
             items.add(getItem(position));
         }
         return items;
@@ -1152,9 +1158,7 @@ public class FastAdapter<Item extends IItem> extends RecyclerView.Adapter<Recycl
         }
         if (entries == null) {
             if (mPositionBasedStateManagement) {
-                if (mSelections.contains(position)) {
-                    mSelections.remove(position);
-                }
+                mSelections.remove(position);
             }
         } else {
             entries.remove();
@@ -1171,7 +1175,7 @@ public class FastAdapter<Item extends IItem> extends RecyclerView.Adapter<Recycl
      * @return a list of the IItem elements which were deleted
      */
     public List<Item> deleteAllSelectedItems() {
-        List<Item> deletedItems = new LinkedList<>();
+        List<Item> deletedItems = new ArrayList<>();
         //we have to re-fetch the selections array again and again as the position will change after one item is deleted
 
         if (mPositionBasedStateManagement) {


### PR DESCRIPTION
Data structures like `HashMap`, or even worse `TreeMap` or `TreeSet` consume way more memory than array-based structures usually recommended for Android like `SparseArray` or the new [`ArraySet`](https://developer.android.com/reference/android/support/v4/util/ArraySet.html). Lookup performance differences are negligible for up to hundreds of items which make array-based structures a perfect fit to store adapters metadata in `FastAdapter`.

This commit only impacts internal data structures of `FastAdapter` and does not change the public API.

**Optimizations in detail:**

- `LinkedList` should be banned. If you need a queue, `ArrayDeque` or `CircularArray` should be used. Here we don't even need that, so a simple `ArrayList` does the same job perfectly.
- `ArrayMap<Integer, X>` can be replaced with `SparseArray<X>`. This avoids boxing the key. `ArrayMap` should only be used when the key is not an `int` or `long`.
- `ArraySet` is a more memory-efficient version of `HashSet` for small collections and implements the same `Set` interface exposed through the API.
- `TreeMap<Integer, X>` can be replaced with `SparseArray<X>` because `SparseArray` uses int keys and always keeps its keys sorted too. To find the floor key value, we can use a neat trick: calling `indexOfKey()` which performs a binary search. It will return the index if found, and if not it will return the bitwise negative position of the upper key, which we can subtract by 1 to get the position of the lower key (-1 if not found).
- We can also optimize the population of `mAdapterSizes` when using a `SparseArray` instead of a regular `Map` by using `append(key, value)` instead of `put(key, value)` because we always add keys in ascending order. This has _O(1)_ performance in all cases instead of _O(log n)_ on average.

I ran all tests and test apps to make sure the commit does not break anything.