### PR TITLE
Small improvements (SubItemUtil, RangeSelector, ActionModeHelper)

### DIFF
--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/ActionModeHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/ActionModeHelper.java
@@ -194,10 +194,12 @@ public class ActionModeHelper {
             }
 
             if (!consumed) {
-                if (mSupportSubItems)
-                    SubItemUtil.deleteSelected(mFastAdapter, true, false); // TODO: unsafe cast!!! for deleting, we need the FastItemAdapter.remove(pos) funtion... adopt this function to work with the FastAdpater instead and the cast can be removed
-                else
+                if (mSupportSubItems) {
+                    SubItemUtil.deleteSelected(mFastAdapter, true, false);
+                }
+                else {
                     mFastAdapter.deleteAllSelectedItems();
+                }
                 //finish the actionMode
                 mode.finish();
             }

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/ActionModeHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/ActionModeHelper.java
@@ -143,6 +143,16 @@ public class ActionModeHelper {
         return checkActionMode(act, selected);
     }
 
+    /**
+     * reset any active action mode if it is active, useful, to avoid leaking the activity if this helper class is retained
+     */
+    public void reset() {
+        if (mActionMode != null) {
+            mActionMode.finish();
+            mActionMode = null;
+        }
+    }
+
     private ActionMode checkActionMode(AppCompatActivity act, int selected) {
         if (selected == 0) {
             if (mActionMode != null) {

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/RangeSelectorHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/RangeSelectorHelper.java
@@ -26,19 +26,34 @@ public class RangeSelectorHelper {
     }
 
     /**
-     * set the ActionModeHelper, if want to notify it after a range was selected
+     * set the ActionModeHelper, if you want to notify it after a range was selected
      * so that it can update the ActionMode title
+     *
+     * @param actionModeHelper the action mode helper that should be used
+     * @return this, for supporting function call chaining
      */
     public RangeSelectorHelper withActionModeHelper(ActionModeHelper actionModeHelper) {
         mActionModeHelper = actionModeHelper;
         return this;
     }
 
+    /**
+     * enable this, if you want the range selector to correclty handle sub items as well
+     *
+     * @param supportSubItems true, if sub items are supported, false otherwise
+     * @return this, for supporting function call chaining
+     */
     public RangeSelectorHelper withSupportSubItems(boolean supportSubItems) {
         this.mSupportSubItems = supportSubItems;
         return this;
     }
 
+    /**
+     * the provided payload will be passed to the adapters notify function, if one is provided
+     *
+     * @param payload the paylaod that should be passed to the adapter on selection state change
+     * @return this, for supporting function call chaining
+     */
     public RangeSelectorHelper withPayload(Object payload) {
         mPayload = payload;
         return this;
@@ -98,10 +113,25 @@ public class RangeSelectorHelper {
         return false;
     }
 
+    /**
+     * selects all items in a range, from and to indizes are inclusive
+     *
+     * @param from the from index
+     * @param to the to index
+     * @param select true, if the provided range should be selected, false otherwise
+     */
     public <T extends IItem & IExpandable> void selectRange(int from, int to, boolean select) {
         selectRange(from, to, select, false);
     }
 
+    /**
+     * selects all items in a range, from and to indizes are inclusive
+     *
+     * @param from the from index
+     * @param to the to index
+     * @param select true, if the provided range should be selected, false otherwise
+     * @param skipHeaders true, if you do not want to process headers, false otherwise
+     */
     public <T extends IItem & IExpandable> void selectRange(int from, int to, boolean select, boolean skipHeaders) {
         if (from > to) {
             int temp = from;

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/RangeSelectorHelper.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/RangeSelectorHelper.java
@@ -17,6 +17,7 @@ public class RangeSelectorHelper {
     private FastItemAdapter mFastAdapter;
     private ActionModeHelper mActionModeHelper;
     private boolean mSupportSubItems = false;
+    private Object mPayload = null;
 
     private Integer mLastLongPressIndex;
 
@@ -35,6 +36,11 @@ public class RangeSelectorHelper {
 
     public RangeSelectorHelper withSupportSubItems(boolean supportSubItems) {
         this.mSupportSubItems = supportSubItems;
+        return this;
+    }
+
+    public RangeSelectorHelper withPayload(Object payload) {
+        mPayload = payload;
         return this;
     }
 
@@ -60,12 +66,25 @@ public class RangeSelectorHelper {
      * @return true, if the long press was handled
      */
     public boolean onLongClick(int index) {
+        return onLongClick(index, true);
+    }
+
+    /**
+     * will take care to save the long pressed index
+     * or to select all items in the range between the current long pressed item and the last long pressed item
+     *
+     * @param index the index of the long pressed item
+     * @param selectItem true, if the item at the index should be selected, false if this was already done outside of this helper or is not desired
+     * @return true, if the long press was handled
+     */
+    public boolean onLongClick(int index, boolean selectItem) {
         if (mLastLongPressIndex == null) {
             // we only consider long presses on not selected items
             if (mFastAdapter.getAdapterItem(index).isSelectable()) {
                 mLastLongPressIndex = index;
                 // we select this item as well
-                mFastAdapter.select(index);
+                if (selectItem)
+                    mFastAdapter.select(index);
                 if (mActionModeHelper != null)
                     mActionModeHelper.checkActionMode(null); // works with null as well, as the ActionMode is active for sure!
                 return true;
@@ -103,7 +122,7 @@ public class RangeSelectorHelper {
             if (mSupportSubItems && !skipHeaders) {
                 // if a group is collapsed, select all sub items
                 if (item instanceof IExpandable && !((IExpandable)item).isExpanded()) {
-                    SubItemUtil.selectAllSubItems(mFastAdapter, (T) mFastAdapter.getAdapterItem(i), select, true);
+                    SubItemUtil.selectAllSubItems(mFastAdapter, (T) mFastAdapter.getAdapterItem(i), select, true, mPayload);
                 }
             }
         }

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/SubItemUtil.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/SubItemUtil.java
@@ -219,7 +219,6 @@ public class SubItemUtil {
                 if (header.getSubItems().get(i) instanceof IExpandable)
                     selectAllSubItems(adapter, header, select, notifyParent, payload);
             }
-
         }
 
         // we must notify the view only!

--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/SubItemUtil.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/SubItemUtil.java
@@ -183,7 +183,7 @@ public class SubItemUtil {
      * @param select the new selected state of the sub items
      */
     public static <T extends IItem & IExpandable> void selectAllSubItems(final FastAdapter adapter, T header, boolean select) {
-        selectAllSubItems(adapter, header, select, false);
+        selectAllSubItems(adapter, header, select, false, null);
     }
 
     /**
@@ -193,8 +193,9 @@ public class SubItemUtil {
      * @param header  the header who's children should be selected or deselected
      * @param select the new selected state of the sub items
      * @param notifyParent true, if the parent should be notified about the changes of its children selection state
+     * @param payload payload for the notifying function
      */
-    public static <T extends IItem & IExpandable> void selectAllSubItems(final FastAdapter adapter, T header, boolean select, boolean notifyParent) {
+    public static <T extends IItem & IExpandable> void selectAllSubItems(final FastAdapter adapter, T header, boolean select, boolean notifyParent, Object payload) {
         int subItems = header.getSubItems().size();
         int position = adapter.getPosition(header);
         if (header.isExpanded()) {
@@ -207,7 +208,7 @@ public class SubItemUtil {
                     }
                 }
                 if (header.getSubItems().get(i) instanceof IExpandable)
-                    selectAllSubItems(adapter, header, select, notifyParent);
+                    selectAllSubItems(adapter, header, select, notifyParent, payload);
 
             }
         } else {
@@ -216,14 +217,14 @@ public class SubItemUtil {
                     ((IItem) header.getSubItems().get(i)).withSetSelected(select);
                 }
                 if (header.getSubItems().get(i) instanceof IExpandable)
-                    selectAllSubItems(adapter, header, select, notifyParent);
+                    selectAllSubItems(adapter, header, select, notifyParent, payload);
             }
 
         }
 
         // we must notify the view only!
         if (notifyParent && position >= 0) {
-            adapter.notifyItemChanged(position);
+            adapter.notifyItemChanged(position, payload);
         }
     }
 
@@ -375,6 +376,9 @@ public class SubItemUtil {
                 boolean success = false;
                 if (adapter instanceof IItemAdapter) {
                     success = ((IItemAdapter) adapter).remove(pos) != null;
+                    if (success) {
+                        fastAdapter.notifyAdapterItemRemoved(pos);
+                    }
                 }
                 boolean isHeader = item instanceof IExpandable && ((IExpandable) item).getSubItems() != null;
 //                Log.d("DELETE", "success=" + success + " | deletedId=" + item.getIdentifier() + "(" + (isHeader ? "EMPTY HEADER" : "ITEM WITHOUT HEADER") + ")");


### PR DESCRIPTION
* action mode helper can be resetted => needed, if you retain the helper on rotation and don't want to leak the activity
* range selector and SubItemUtil supports a payload for a more effective notifying of the adapter

I saw, that the `FastAdapter.select()` does not yet support payloads for the select functions, I think it should though...