### PR TITLE
Fix: failed withSavedInstanceState if withPositionBasedStateManagement(false)

### DIFF
--- a/library-core/src/main/java/com/mikepenz/fastadapter/FastAdapter.java
+++ b/library-core/src/main/java/com/mikepenz/fastadapter/FastAdapter.java
@@ -367,6 +367,7 @@ public class FastAdapter<Item extends IItem> extends RecyclerView.Adapter<Recycl
                     id = String.valueOf(item.getIdentifier());
                     if (expandedItems != null && expandedItems.contains(id)) {
                         expand(i);
+                        size = getItemCount();
                     }
                     if (selectedItems != null && selectedItems.contains(id)) {
                         select(i);


### PR DESCRIPTION
I can't think of better idea to solve #360 other than this one-line fix, or to loop until exception thrown at `item = getItem(i);` instead of `i < size` (python style).