### PR TITLE
DragDropUtil onMove fixed

### DIFF
--- a/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/DragDropUtil.java
+++ b/library-extensions/src/main/java/com/mikepenz/fastadapter_extensions/utilities/DragDropUtil.java
@@ -49,9 +49,9 @@ public class DragDropUtil
     public static void onMove(FastItemAdapter fastItemAdapter, int oldPosition, int newPosition) {
         // necessary, because the positions passed to this function may be jumping in case of that the recycler view is scrolled while holding an item outside of the recycler view
         if (oldPosition < newPosition) {
-            for (int i = newPosition - 1; i >= oldPosition; i--) {
-                Collections.swap(fastItemAdapter.getAdapterItems(), i, i + 1);
-                fastItemAdapter.notifyAdapterItemMoved(i, i + 1);
+            for (int i = oldPosition + 1; i <= newPosition; i++) {
+                Collections.swap(fastItemAdapter.getAdapterItems(), i, i - 1);
+                fastItemAdapter.notifyAdapterItemMoved(i, i - 1);
             }
         } else {
             for (int i = oldPosition - 1; i >= newPosition; i--) {


### PR DESCRIPTION
The order of exchanging items was not working with grids, now it's working with grids as well