### PR TITLE
Allow DiffUtil to calculate on background thread

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -105,4 +105,8 @@ dependencies {
     compile('com.mopub:mopub-sdk:4.7.1@aar') {
         transitive = true
     }
+
+    //Used to async operations
+    compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
+    compile 'io.reactivex.rxjava2:rxjava:2.1.2'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -72,6 +72,9 @@
         <activity
             android:name="com.mikepenz.fastadapter.app.StickyHeaderMopubAdsActivity"
             android:label="@string/sample_sticky_header_mopub" />
+        <activity
+            android:name="com.mikepenz.fastadapter.app.DiffUtilActivity"
+            android:label="@string/sample_diff_util" />
 
         <!-- USED FOR THE MopubAdsActivity sample-->
         <activity

--- a/app/src/main/java/com/mikepenz/fastadapter/app/DiffUtilActivity.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/DiffUtilActivity.java
@@ -136,7 +136,7 @@ public class DiffUtilActivity extends AppCompatActivity {
             public DiffUtil.DiffResult apply(List<SimpleItem> simpleItems) throws Exception {
                 return FastAdapterDiffUtil.calculateDiff(fastItemAdapter, simpleItems);
             }
-        }).subscribeOn(Schedulers.newThread())
+        }).subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(new Consumer<DiffUtil.DiffResult>() {
                     @Override

--- a/app/src/main/java/com/mikepenz/fastadapter/app/DiffUtilActivity.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/DiffUtilActivity.java
@@ -1,0 +1,165 @@
+package com.mikepenz.fastadapter.app;
+
+import android.graphics.Color;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.util.DiffUtil;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.Toolbar;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.Toast;
+
+import com.mikepenz.fastadapter.app.items.SimpleItem;
+import com.mikepenz.fastadapter.commons.adapters.FastItemAdapter;
+import com.mikepenz.fastadapter.commons.utils.FastAdapterDiffUtil;
+import com.mikepenz.iconics.IconicsDrawable;
+import com.mikepenz.itemanimators.AlphaInAnimator;
+import com.mikepenz.material_design_iconic_typeface_library.MaterialDesignIconic;
+import com.mikepenz.materialize.MaterializeBuilder;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import io.reactivex.Single;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.functions.Consumer;
+import io.reactivex.functions.Function;
+import io.reactivex.schedulers.Schedulers;
+
+/**
+ * Created by Aleksander Mielczarek on 07.08.2017.
+ */
+
+public class DiffUtilActivity extends AppCompatActivity {
+
+    //save our FastAdapter
+    private FastItemAdapter<SimpleItem> fastItemAdapter;
+    private final CompositeDisposable disposables = new CompositeDisposable();
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        findViewById(android.R.id.content).setSystemUiVisibility(findViewById(android.R.id.content).getSystemUiVisibility() | View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_sample);
+
+        // Handle Toolbar
+        Toolbar toolbar = findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+        getSupportActionBar().setTitle(R.string.sample_diff_util);
+
+        //style our ui
+        new MaterializeBuilder().withActivity(this).build();
+
+        //create our FastAdapter which will manage everything
+        fastItemAdapter = new FastItemAdapter<>();
+
+        //get our recyclerView and do basic setup
+        RecyclerView rv = findViewById(R.id.rv);
+        rv.setLayoutManager(new LinearLayoutManager(this));
+        rv.setItemAnimator(new AlphaInAnimator());
+        rv.setAdapter(fastItemAdapter);
+
+        //fill with some sample data
+        setData();
+
+        //set the back arrow in the toolbar
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        getSupportActionBar().setHomeButtonEnabled(false);
+
+        //restore selections (this has to be done after the items were added
+        fastItemAdapter.withSavedInstanceState(savedInstanceState);
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        //add the values which need to be saved from the adapter to the bundel
+        outState = fastItemAdapter.saveInstanceState(outState);
+        super.onSaveInstanceState(outState);
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.refresh, menu);
+        menu.findItem(R.id.item_refresh).setIcon(new IconicsDrawable(this, MaterialDesignIconic.Icon.gmi_refresh).color(Color.BLACK).actionBar());
+        menu.findItem(R.id.item_refresh_async).setIcon(new IconicsDrawable(this, MaterialDesignIconic.Icon.gmi_refresh_sync).color(Color.BLACK).actionBar());
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        //handle the click on the back arrow click
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                onBackPressed();
+                return true;
+            case R.id.item_refresh:
+                setData();
+                Toast.makeText(this, "Refresh synchronous", Toast.LENGTH_SHORT).show();
+                return true;
+            case R.id.item_refresh_async:
+                setDataAsync();
+                Toast.makeText(this, "Refresh asynchronous", Toast.LENGTH_SHORT).show();
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        disposables.clear();
+    }
+
+    private void setData() {
+        List<SimpleItem> items = createData();
+        FastAdapterDiffUtil.set(fastItemAdapter, items);
+    }
+
+    private void setDataAsync() {
+        disposables.add(Single.fromCallable(new Callable<List<SimpleItem>>() {
+            @Override
+            public List<SimpleItem> call() throws Exception {
+                return createData();
+            }
+        }).map(new Function<List<SimpleItem>, DiffUtil.DiffResult>() {
+            @Override
+            public DiffUtil.DiffResult apply(List<SimpleItem> simpleItems) throws Exception {
+                return FastAdapterDiffUtil.calculateDiff(fastItemAdapter, simpleItems);
+            }
+        }).subscribeOn(Schedulers.newThread())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(new Consumer<DiffUtil.DiffResult>() {
+                    @Override
+                    public void accept(DiffUtil.DiffResult result) throws Exception {
+                        FastAdapterDiffUtil.set(fastItemAdapter, result);
+                    }
+                }));
+    }
+
+    private List<SimpleItem> createData() {
+        List<SimpleItem> items = Arrays.asList(
+                new SimpleItem().withName("Item 1").withIdentifier(1),
+                new SimpleItem().withName("Item 2").withIdentifier(2),
+                new SimpleItem().withName("Item 3").withIdentifier(3),
+                new SimpleItem().withName("Item 4").withIdentifier(4),
+                new SimpleItem().withName("Item 5").withIdentifier(5),
+                new SimpleItem().withName("Item 6").withIdentifier(6),
+                new SimpleItem().withName("Item 7").withIdentifier(7),
+                new SimpleItem().withName("Item 8").withIdentifier(8),
+                new SimpleItem().withName("Item 9").withIdentifier(9),
+                new SimpleItem().withName("Item 10").withIdentifier(10)
+        );
+        Collections.shuffle(items);
+        return items;
+    }
+}

--- a/app/src/main/java/com/mikepenz/fastadapter/app/SampleActivity.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/SampleActivity.java
@@ -83,6 +83,7 @@ public class SampleActivity extends AppCompatActivity {
                         new PrimaryDrawerItem().withName(R.string.sample_realm_list).withDescription(R.string.sample_realm_list_descr).withSelectable(false).withIdentifier(16).withIcon(MaterialDesignIconic.Icon.gmi_format_color_text),
                         new PrimaryDrawerItem().withName(R.string.sample_collapsible_multi_select_delete).withDescription(R.string.sample_collapsible_multi_select_delete_descr).withSelectable(false).withIdentifier(17).withIcon(MaterialDesignIconic.Icon.gmi_check_all),
                         new PrimaryDrawerItem().withName(R.string.sample_sticky_header_mopub).withDescription(R.string.sample_sticky_header_mopub_descr).withSelectable(false).withIdentifier(18).withIcon(MaterialDesignIconic.Icon.gmi_accounts_list),
+                        new PrimaryDrawerItem().withName(R.string.sample_diff_util).withDescription(R.string.sample_diff_util_descr).withSelectable(false).withIdentifier(19).withIcon(MaterialDesignIconic.Icon.gmi_refresh),
                         new DividerDrawerItem(),
                         new PrimaryDrawerItem().withName(R.string.open_source).withSelectable(false).withIdentifier(100).withIcon(MaterialDesignIconic.Icon.gmi_github)
                 )
@@ -127,6 +128,8 @@ public class SampleActivity extends AppCompatActivity {
                                 intent = new Intent(SampleActivity.this, ExpandableMultiselectDeleteSampleActivity.class);
                             } else if (drawerItem.getIdentifier() == 18) {
                                 intent = new Intent(SampleActivity.this, StickyHeaderMopubAdsActivity.class);
+                            } else if (drawerItem.getIdentifier() == 19) {
+                                intent = new Intent(SampleActivity.this, DiffUtilActivity.class);
                             } else if (drawerItem.getIdentifier() == 100) {
                                 intent = new LibsBuilder()
                                         .withFields(R.string.class.getFields())

--- a/app/src/main/res/menu/refresh.xml
+++ b/app/src/main/res/menu/refresh.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/item_refresh"
+        android:title="Refresh"
+        android:titleCondensed="Refresh"
+        app:showAsAction="always"/>
+
+    <item
+        android:id="@+id/item_refresh_async"
+        android:title="Refresh async"
+        android:titleCondensed="Refresh"
+        app:showAsAction="always"/>
+
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,8 @@
     <string name="sample_sticky_header_mopub_descr">Simple sticky header mopub adapter usage example</string>
     <string name="sample_realm_list">Realm Sample</string>
     <string name="sample_realm_list_descr">Realm, Implement IItem interface</string>
+    <string name="sample_diff_util">Diff Util Sample</string>
+    <string name="sample_diff_util_descr">Diff Util, refresh list using DiffUtil</string>
     <string name="open_source">Open Source</string>
     <string name="search_title">Suche</string>
     <string name="action_undo">UNDO</string>

--- a/library/src/main/java/com/mikepenz/fastadapter/commons/utils/FastAdapterDiffUtil.java
+++ b/library/src/main/java/com/mikepenz/fastadapter/commons/utils/FastAdapterDiffUtil.java
@@ -6,6 +6,7 @@ import android.support.v7.util.ListUpdateCallback;
 
 import com.mikepenz.fastadapter.IItem;
 import com.mikepenz.fastadapter.adapters.ItemAdapter;
+import com.mikepenz.fastadapter.commons.adapters.FastItemAdapter;
 
 import java.util.Collections;
 import java.util.List;
@@ -15,7 +16,8 @@ import java.util.List;
  */
 
 public class FastAdapterDiffUtil {
-    public static <A extends ItemAdapter<Item>, Item extends IItem> A set(final A adapter, final List<Item> items, final DiffCallback<Item> callback, final boolean detectMoves) {
+
+    public static <A extends ItemAdapter<Item>, Item extends IItem> DiffUtil.DiffResult calculateDiff(final A adapter, final List<Item> items, final DiffCallback<Item> callback, final boolean detectMoves) {
         if (adapter.isUseIdDistributor()) {
             adapter.getIdDistributor().checkIds(items);
         }
@@ -31,34 +33,7 @@ public class FastAdapterDiffUtil {
         //remember the old items
         final List<Item> oldItems = adapter.getAdapterItems();
 
-        DiffUtil.DiffResult result = DiffUtil.calculateDiff(new DiffUtil.Callback() {
-            @Override
-            public int getOldListSize() {
-                return oldItems.size();
-            }
-
-            @Override
-            public int getNewListSize() {
-                return items.size();
-            }
-
-            @Override
-            public boolean areItemsTheSame(int oldItemPosition, int newItemPosition) {
-                return callback.areItemsTheSame(oldItems.get(oldItemPosition), items.get(newItemPosition));
-            }
-
-            @Override
-            public boolean areContentsTheSame(int oldItemPosition, int newItemPosition) {
-                return callback.areContentsTheSame(oldItems.get(oldItemPosition), items.get(newItemPosition));
-            }
-
-            @Nullable
-            @Override
-            public Object getChangePayload(int oldItemPosition, int newItemPosition) {
-                Object result = callback.getChangePayload(oldItems.get(oldItemPosition), oldItemPosition, items.get(newItemPosition), newItemPosition);
-                return result == null ? super.getChangePayload(oldItemPosition, newItemPosition) : result;
-            }
-        }, detectMoves);
+        DiffUtil.DiffResult result = DiffUtil.calculateDiff(new FastAdapterCallback<>(oldItems, items, callback), detectMoves);
 
         //make sure the new items list is not a reference of the already mItems list
         if (items != oldItems) {
@@ -71,28 +46,145 @@ public class FastAdapterDiffUtil {
             oldItems.addAll(items);
         }
 
-        result.dispatchUpdatesTo(new ListUpdateCallback() {
-            @Override
-            public void onInserted(int position, int count) {
-                adapter.getFastAdapter().notifyAdapterItemRangeInserted(adapter.getFastAdapter().getPreItemCountByOrder(adapter.getOrder()) + position, count);
-            }
+        return result;
+    }
 
-            @Override
-            public void onRemoved(int position, int count) {
-                adapter.getFastAdapter().notifyAdapterItemRangeRemoved(adapter.getFastAdapter().getPreItemCountByOrder(adapter.getOrder()) + position, count);
-            }
-
-            @Override
-            public void onMoved(int fromPosition, int toPosition) {
-                adapter.getFastAdapter().notifyAdapterItemMoved(adapter.getFastAdapter().getPreItemCountByOrder(adapter.getOrder()) + fromPosition, toPosition);
-            }
-
-            @Override
-            public void onChanged(int position, int count, Object payload) {
-                adapter.getFastAdapter().notifyAdapterItemRangeChanged(adapter.getFastAdapter().getPreItemCountByOrder(adapter.getOrder()) + position, count, payload);
-            }
-        });
-
+    public static <A extends ItemAdapter<Item>, Item extends IItem> A set(final A adapter, DiffUtil.DiffResult result) {
+        result.dispatchUpdatesTo(new FastAdapterListUpdateCallback<>(adapter));
         return adapter;
+    }
+
+    public static <A extends ItemAdapter<Item>, Item extends IItem> DiffUtil.DiffResult calculateDiff(final A adapter, final List<Item> items, final DiffCallback<Item> callback) {
+        return calculateDiff(adapter, items, callback, true);
+    }
+
+    public static <A extends ItemAdapter<Item>, Item extends IItem> DiffUtil.DiffResult calculateDiff(final A adapter, final List<Item> items, final boolean detectMoves) {
+        return calculateDiff(adapter, items, new DiffCallbackImpl<Item>(), detectMoves);
+    }
+
+    public static <A extends ItemAdapter<Item>, Item extends IItem> DiffUtil.DiffResult calculateDiff(final A adapter, final List<Item> items) {
+        return calculateDiff(adapter, items, new DiffCallbackImpl<Item>(), true);
+    }
+
+    public static <A extends FastItemAdapter<Item>, Item extends IItem> DiffUtil.DiffResult calculateDiff(final A adapter, final List<Item> items, final DiffCallback<Item> callback) {
+        return calculateDiff(adapter.getItemAdapter(), items, callback);
+    }
+
+    public static <A extends FastItemAdapter<Item>, Item extends IItem> DiffUtil.DiffResult calculateDiff(final A adapter, final List<Item> items, final boolean detectMoves) {
+        return calculateDiff(adapter.getItemAdapter(), items, detectMoves);
+    }
+
+    public static <A extends FastItemAdapter<Item>, Item extends IItem> DiffUtil.DiffResult calculateDiff(final A adapter, final List<Item> items) {
+        return calculateDiff(adapter.getItemAdapter(), items);
+    }
+
+    public static <A extends ItemAdapter<Item>, Item extends IItem> A set(final A adapter, final List<Item> items, final DiffCallback<Item> callback, final boolean detectMoves) {
+        DiffUtil.DiffResult result = calculateDiff(adapter, items, callback, detectMoves);
+        return set(adapter, result);
+    }
+
+    public static <A extends ItemAdapter<Item>, Item extends IItem> A set(final A adapter, final List<Item> items, final DiffCallback<Item> callback) {
+        return set(adapter, items, callback, true);
+    }
+
+    public static <A extends ItemAdapter<Item>, Item extends IItem> A set(final A adapter, final List<Item> items, final boolean detectMoves) {
+        return set(adapter, items, new DiffCallbackImpl<Item>(), detectMoves);
+    }
+
+    public static <A extends ItemAdapter<Item>, Item extends IItem> A set(final A adapter, final List<Item> items) {
+        return set(adapter, items, new DiffCallbackImpl<Item>());
+    }
+
+    public static <A extends FastItemAdapter<Item>, Item extends IItem> A set(final A adapter, final List<Item> items, final DiffCallback<Item> callback, final boolean detectMoves) {
+        set(adapter.getItemAdapter(), items, callback, detectMoves);
+        return adapter;
+    }
+
+    public static <A extends FastItemAdapter<Item>, Item extends IItem> A set(final A adapter, final List<Item> items, final DiffCallback<Item> callback) {
+        set(adapter.getItemAdapter(), items, callback);
+        return adapter;
+    }
+
+    public static <A extends FastItemAdapter<Item>, Item extends IItem> A set(final A adapter, final List<Item> items, final boolean detectMoves) {
+        set(adapter.getItemAdapter(), items, detectMoves);
+        return adapter;
+    }
+
+    public static <A extends FastItemAdapter<Item>, Item extends IItem> A set(final A adapter, final List<Item> items) {
+        return set(adapter, items, new DiffCallbackImpl<Item>());
+    }
+
+    public static <A extends FastItemAdapter<Item>, Item extends IItem> A set(final A adapter, DiffUtil.DiffResult result) {
+        set(adapter.getItemAdapter(), result);
+        return adapter;
+    }
+
+    private static final class FastAdapterCallback<Item extends IItem> extends DiffUtil.Callback {
+
+        private final List<Item> oldItems;
+        private final List<Item> items;
+        private final DiffCallback<Item> callback;
+
+        FastAdapterCallback(List<Item> oldItems, List<Item> items, DiffCallback<Item> callback) {
+            this.oldItems = oldItems;
+            this.items = items;
+            this.callback = callback;
+        }
+
+        @Override
+        public int getOldListSize() {
+            return oldItems.size();
+        }
+
+        @Override
+        public int getNewListSize() {
+            return items.size();
+        }
+
+        @Override
+        public boolean areItemsTheSame(int oldItemPosition, int newItemPosition) {
+            return callback.areItemsTheSame(oldItems.get(oldItemPosition), items.get(newItemPosition));
+        }
+
+        @Override
+        public boolean areContentsTheSame(int oldItemPosition, int newItemPosition) {
+            return callback.areContentsTheSame(oldItems.get(oldItemPosition), items.get(newItemPosition));
+        }
+
+        @Nullable
+        @Override
+        public Object getChangePayload(int oldItemPosition, int newItemPosition) {
+            Object result = callback.getChangePayload(oldItems.get(oldItemPosition), oldItemPosition, items.get(newItemPosition), newItemPosition);
+            return result == null ? super.getChangePayload(oldItemPosition, newItemPosition) : result;
+        }
+    }
+
+    private static final class FastAdapterListUpdateCallback<A extends ItemAdapter<Item>, Item extends IItem> implements ListUpdateCallback {
+
+        private final A adapter;
+
+        FastAdapterListUpdateCallback(A adapter) {
+            this.adapter = adapter;
+        }
+
+        @Override
+        public void onInserted(int position, int count) {
+            adapter.getFastAdapter().notifyAdapterItemRangeInserted(adapter.getFastAdapter().getPreItemCountByOrder(adapter.getOrder()) + position, count);
+        }
+
+        @Override
+        public void onRemoved(int position, int count) {
+            adapter.getFastAdapter().notifyAdapterItemRangeRemoved(adapter.getFastAdapter().getPreItemCountByOrder(adapter.getOrder()) + position, count);
+        }
+
+        @Override
+        public void onMoved(int fromPosition, int toPosition) {
+            adapter.getFastAdapter().notifyAdapterItemMoved(adapter.getFastAdapter().getPreItemCountByOrder(adapter.getOrder()) + fromPosition, toPosition);
+        }
+
+        @Override
+        public void onChanged(int position, int count, Object payload) {
+            adapter.getFastAdapter().notifyAdapterItemRangeChanged(adapter.getFastAdapter().getPreItemCountByOrder(adapter.getOrder()) + position, count, payload);
+        }
     }
 }


### PR DESCRIPTION
`FastAdapterDiffUtil` contains new method `calculateDiff` to allow calculate diff on background thread and later dispatch result to recycler on main thread using `set.`

Change is backward compatible.
Example included.