### PR TITLE
Fix collapse bug in expandable extention

### DIFF
--- a/app/src/main/java/com/mikepenz/fastadapter/app/ExpandableSampleActivity.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/ExpandableSampleActivity.java
@@ -58,6 +58,19 @@ public class ExpandableSampleActivity extends AppCompatActivity {
 
         //fill with some sample data
         List<IItem> items = new ArrayList<>();
+
+        //see https://github.com/mikepenz/FastAdapter/pull/588
+        SimpleSubExpandableItem parentItem = new SimpleSubExpandableItem().withName("Expandable Parent Item");
+        List<IItem> parentSubItems = new LinkedList<>();
+        SimpleSubExpandableItem subItem = new SimpleSubExpandableItem().withName("-- Expandable Sub Item");
+        List<IItem> subSubItems = new LinkedList<>();
+        SimpleSubItem subSubItem = new SimpleSubItem().withName("---- Simple Sub Sub Item");
+        subSubItems.add(subSubItem);
+        subItem.withSubItems(subSubItems);
+        parentSubItems.add(subItem);
+        parentItem.withSubItems(parentSubItems);
+        items.add(parentItem);
+
         for (int i = 1; i <= 100; i++) {
             if (i % 10 == 0) {
                 SimpleSubExpandableItem expandableItem = new SimpleSubExpandableItem();

--- a/library-extensions-expandable/src/main/java/com/mikepenz/fastadapter/expandable/ExpandableExtension.java
+++ b/library-extensions-expandable/src/main/java/com/mikepenz/fastadapter/expandable/ExpandableExtension.java
@@ -306,7 +306,7 @@ public class ExpandableExtension<Item extends IItem> implements IAdapterExtensio
                 //first we find out how many items were added in total
                 //also counting subitems
                 int totalAddedItems = expandable.getSubItems().size();
-                for (int i = position + 1; i < position + totalAddedItems; i++) {
+                for (int i = position + 1; i <= position + totalAddedItems; i++) {
                     Item tmp = mFastAdapter.getItem(i);
                     if (tmp instanceof IExpandable) {
                         IExpandable tmpExpandable = ((IExpandable) tmp);


### PR DESCRIPTION
First thanks for the great library! We are using it at [Transportr](/grote/Transportr) and playing a bit, I found the following bug when collapsing a sub-item with only one sub-sub-item: The sub-sub-item will still remain in place instead of being hidden by collapsing the sub-item.

The fix should be as simply as adding an `=` sign to count the sub-items properly. I didn't build nor test the change, but should work as is.