### PR TITLE
Fix "only one expanded item" function on multi level hierarchies

### DIFF
--- a/app/src/main/java/com/mikepenz/fastadapter/app/ExpandableSampleActivity.java
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/ExpandableSampleActivity.java
@@ -48,6 +48,7 @@ public class ExpandableSampleActivity extends AppCompatActivity {
         fastItemAdapter = new FastItemAdapter<>();
         fastItemAdapter.withSelectable(true);
         expandableExtension = new ExpandableExtension<>();
+        expandableExtension.withOnlyOneExpandedItem(true);
         fastItemAdapter.addExtension(expandableExtension);
 
         //get our recyclerView and do basic setup
@@ -68,11 +69,22 @@ public class ExpandableSampleActivity extends AppCompatActivity {
                 //add subitems so we can showcase the collapsible functionality
                 List<IItem> subItems = new LinkedList<>();
                 for (int ii = 1; ii <= 5; ii++) {
-                    SimpleSubItem sampleItem = new SimpleSubItem();
-                    sampleItem
+                    subItem = new SimpleSubExpandableItem();
+                    subItem
                             .withName("-- Test " + ii)
                             .withIdentifier(1000 + ii);
-                    subItems.add(sampleItem);
+
+                    subSubItems = new LinkedList<>();
+                    for (int iii=1; iii<=5;iii++) {
+                        subSubItem = new SimpleSubItem();
+                        subSubItem
+                                .withName("--- Test " + iii)
+                                .withIdentifier(10000 + iii);
+                        subSubItems.add(subSubItem);
+                    }
+                    subItem.withSubItems(subSubItems);
+
+                    subItems.add(subItem);
                 }
                 expandableItem.withSubItems(subItems);
 

--- a/library-extensions-expandable/src/main/java/com/mikepenz/fastadapter/expandable/ExpandableExtension.java
+++ b/library-extensions-expandable/src/main/java/com/mikepenz/fastadapter/expandable/ExpandableExtension.java
@@ -12,6 +12,7 @@ import com.mikepenz.fastadapter.IAdapterExtension;
 import com.mikepenz.fastadapter.IExpandable;
 import com.mikepenz.fastadapter.IItem;
 import com.mikepenz.fastadapter.IItemAdapter;
+import com.mikepenz.fastadapter.ISubItem;
 import com.mikepenz.fastadapter.select.SelectExtension;
 import com.mikepenz.fastadapter.utils.AdapterUtil;
 
@@ -118,7 +119,7 @@ public class ExpandableExtension<Item extends IItem> implements IAdapterExtensio
         //if there should be only one expanded item we want to collapse all the others but the current one (this has to happen after we handled the selection as we refer to the position)
         if (!consumed && mOnlyOneExpandedItem && item instanceof IExpandable) {
             if (((IExpandable) item).getSubItems() != null && ((IExpandable) item).getSubItems().size() > 0) {
-                int[] expandedItems = getExpandedItems();
+                int[] expandedItems = getExpandedItemsSameLevel(pos);
                 for (int i = expandedItems.length - 1; i >= 0; i--) {
                     if (expandedItems[i] != pos) {
                         collapse(expandedItems[i], true);
@@ -236,6 +237,70 @@ public class ExpandableExtension<Item extends IItem> implements IAdapterExtensio
             item = mFastAdapter.getItem(i);
             if (item instanceof IExpandable && ((IExpandable) item).isExpanded()) {
                 expandedItemsList.add(i);
+            }
+        }
+
+        int expandedItemsListLength = expandedItemsList.size();
+        expandedItems = new int[expandedItemsListLength];
+        for (int i = 0; i < expandedItemsListLength; i++) {
+            expandedItems[i] = expandedItemsList.get(i);
+        }
+        return expandedItems;
+    }
+
+    /**
+     * @param position the global position of the current item
+     *
+     * @return a set with the global positions of all expanded items on the same level as the current item
+     */
+    public int[] getExpandedItemsSameLevel(int position) {
+        Item item = mFastAdapter.getItem(position);
+        if (!(item instanceof ISubItem)) {
+            //if it isn't a SubItem, has to be on the root level
+            return getExpandedItemsRootLevel(position);
+        } else {
+            IItem parent = ((ISubItem) item).getParent();
+            if (!(parent instanceof IExpandable)) {
+                //if it has no parent, has to be on the root level
+                return getExpandedItemsRootLevel(position);
+            }
+
+            //if it is a SubItem and has a parent, only return the expanded items on the same level
+            int[] expandedItems;
+            ArrayList<Integer> expandedItemsList = new ArrayList<>();
+            for (Object subItem : ((IExpandable) parent).getSubItems()) {
+                if (subItem instanceof IExpandable && ((IExpandable) subItem).isExpanded() && subItem != item) {
+                    expandedItemsList.add(mFastAdapter.getPosition((Item) subItem));
+                }
+            }
+            int expandedItemsListLength = expandedItemsList.size();
+            expandedItems = new int[expandedItemsListLength];
+            for (int i = 0; i < expandedItemsListLength; i++) {
+                expandedItems[i] = expandedItemsList.get(i);
+            }
+            return expandedItems;
+        }
+    }
+
+    /**
+     * @param position the global position of the current item
+     *
+     * @return a set with the global positions of all expanded items on the root level
+     */
+    public int[] getExpandedItemsRootLevel(int position) {
+        int[] expandedItems;
+        ArrayList<Integer> expandedItemsList = new ArrayList<>();
+        Item item = mFastAdapter.getItem(position);
+
+        for (int i = 0, size = mFastAdapter.getItemCount(); i < size; i++) {
+            Item currItem = mFastAdapter.getItem(i);
+            if (currItem instanceof ISubItem) {
+                IItem parent = ((ISubItem)currItem).getParent();
+                if (parent instanceof IExpandable && ((IExpandable)parent).isExpanded()) {
+                    i += ((IExpandable)parent).getSubItems().size();
+                    if (parent != item)
+                        expandedItemsList.add(mFastAdapter.getPosition((Item)parent));
+                }
             }
         }
 


### PR DESCRIPTION
I've continued playing with the library at [Transportr](/grote/Transportr), this time with the `withOnlyOneExpandedItem` function. In the current version, *all* other expanded items will be collapsed, including the possible (expanded) parent item, so at the end, nothing stays expanded.

Same thing as in the other pull request: First commit extends the sample app to see the bug inside `ExpandableSampleActivity.java`, the second commit fixes the bug by only collapsing expanded items on the same level as the newly expanded item.