### PR TITLE
increase type safety and convenience of getExtension

### DIFF
--- a/library-core/src/main/java/com/mikepenz/fastadapter/FastAdapter.java
+++ b/library-core/src/main/java/com/mikepenz/fastadapter/FastAdapter.java
@@ -249,7 +249,7 @@ public class FastAdapter<Item extends IItem> extends RecyclerView.Adapter<Recycl
      */
     @Nullable
     @SuppressWarnings("unchecked")
-    public <T extends IAdapterExtension<Item>> T getExtension(Class clazz) {
+    public <T extends IAdapterExtension<Item>> T getExtension(Class<? super T> clazz) {
         return (T) mExtensions.get(clazz);
     }
 


### PR DESCRIPTION
```java
((ExpandableExtension<Item>)fastAdapter.getExtension(ExpandableExtension.class)).getExpandedItems()
```
becomes
```java
fastAdapter.<ExpandableExtension<Item>>getExtension(ExpandableExtension.class).getExpandedItems()
```
with no downside.