### PR TITLE
Fixed UndoHelper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.1.1'
         classpath 'com.novoda:bintray-release:0.8.1'
         classpath "io.realm:realm-gradle-plugin:4.1.1"
     }


### PR DESCRIPTION
When items get deleted to fast, they were not removed from the recyclerView, because notifyCommit() was also called on the new inserted history (once to often).

Unwanted sequence:
User calls remove() -> creates History 1 -> call show() Snackbar 1 -> onShown() executes doChange() -> user calls remove() before Snackbar 1 dismissed -> notifyCommit() called for History 1 -> creates new History 2 -> call show() Snackbar 2 -> Snackbar 1 dismissed by consecutive event -> notifyCommit() on History 2 -> Snackbar 2 onShown() -> doChange() is called on null History -> History 2 not removed from recycler view