### PR TITLE
Modified Documentation on withSelectable

### DIFF
--- a/library-core/src/main/java/com/mikepenz/fastadapter/FastAdapter.java
+++ b/library-core/src/main/java/com/mikepenz/fastadapter/FastAdapter.java
@@ -439,7 +439,8 @@ public class FastAdapter<Item extends IItem> extends RecyclerView.Adapter<Recycl
     }
 
     /**
-     * set if no item is selectable
+     * Set to true if you want the items to be selectable. 
+     * By default, no items are selectable
      *
      * @param selectable true if items are selectable
      * @return this


### PR DESCRIPTION
The Java doc was misleading. It is actually required to set withSelectable to true to allow multi selection and by default, no items are selectable.