### PR TITLE
Use interface and delegation for FastItemAdapter

### DIFF
--- a/library-core/src/main/java/com/mikepenz/fastadapter/FastAdapter.kt
+++ b/library-core/src/main/java/com/mikepenz/fastadapter/FastAdapter.kt
@@ -41,16 +41,13 @@ open class FastAdapter<Item : IItem<out RecyclerView.ViewHolder>> :
     // we remember all adapters
     //priority queue...
     private val adapters = ArrayList<IAdapter<Item>>()
-    // we remember all possible types so we can create a new view efficiently
-    /**
-     * @return the current type instance cache
-     */
+
     /**
      * Sets an type instance cache to this fast adapter instance.
      * The cache will manage the type instances to create new views more efficient.
      * Normally an shared cache is used over all adapter instances.
      *
-     * @param mTypeInstanceCache a custom `TypeInstanceCache` implementation
+     * typeInstanceCache a custom `TypeInstanceCache` implementation
      */
     open var typeInstanceCache: ITypeInstanceCache<Item> = DefaultTypeInstanceCache()
     // cache the sizes of the different adapters so we can access the items more performant

--- a/library-core/src/main/java/com/mikepenz/fastadapter/IItemAdapter.kt
+++ b/library-core/src/main/java/com/mikepenz/fastadapter/IItemAdapter.kt
@@ -8,6 +8,11 @@ import androidx.recyclerview.widget.RecyclerView
 interface IItemAdapter<Model, Item : IItem<out RecyclerView.ViewHolder>> : IAdapter<Item> {
 
     /**
+     * The [IIdDistributor] used to provide identifiers to added items (if no identifier was specified prior)
+     */
+    var idDistributor: IIdDistributor<Item>
+
+    /**
      * set a new list of items and apply it to the existing list (clear - add) for this adapter
      *
      * @param items
@@ -19,7 +24,7 @@ interface IItemAdapter<Model, Item : IItem<out RecyclerView.ViewHolder>> : IAdap
      *
      * @param items
      */
-    fun setNewList(items: List<Model>): IItemAdapter<Model, Item>
+    fun setNewList(items: List<Model>, retainFilter: Boolean = false): IItemAdapter<Model, Item>
 
     /**
      * add an array of items to the end of the existing items
@@ -83,6 +88,11 @@ interface IItemAdapter<Model, Item : IItem<out RecyclerView.ViewHolder>> : IAdap
     fun setInternal(position: Int, item: Item): IItemAdapter<Model, Item>
 
     /**
+     * moves the item at the [fromPosition] to the [toPosition]
+     */
+    fun move(fromPosition: Int, toPosition: Int): IItemAdapter<Model, Item>
+
+    /**
      * removes an item at the given position within the existing icons
      *
      * @param position the global position
@@ -101,4 +111,11 @@ interface IItemAdapter<Model, Item : IItem<out RecyclerView.ViewHolder>> : IAdap
      * removes all items of this adapter
      */
     fun clear(): IItemAdapter<Model, Item>
+
+    /**
+     * filters the items with the constraint using the provided Predicate
+     *
+     * @param constraint the string used to filter the list
+     */
+    fun filter(constraint: CharSequence?)
 }

--- a/library-core/src/main/java/com/mikepenz/fastadapter/adapters/ModelAdapter.kt
+++ b/library-core/src/main/java/com/mikepenz/fastadapter/adapters/ModelAdapter.kt
@@ -32,7 +32,7 @@ open class ModelAdapter<Model, Item : IItem<out RecyclerView.ViewHolder>>(
 
     open var reverseInterceptor: ((element: Item) -> Model?)? = null
 
-    open var idDistributor: IIdDistributor<Item> = IIdDistributor.DEFAULT as IIdDistributor<Item>
+    override var idDistributor: IIdDistributor<Item> = IIdDistributor.DEFAULT as IIdDistributor<Item>
 
     /**
      * Defines if the DefaultIdDistributor is used to provide an ID to all added items which do not yet define an id
@@ -121,7 +121,7 @@ open class ModelAdapter<Model, Item : IItem<out RecyclerView.ViewHolder>>(
      *
      * @param constraint the string used to filter the list
      */
-    open fun filter(constraint: CharSequence?) {
+    override fun filter(constraint: CharSequence?) {
         itemFilter.filter(constraint)
     }
 
@@ -236,20 +236,11 @@ open class ModelAdapter<Model, Item : IItem<out RecyclerView.ViewHolder>>(
     /**
      * sets a complete new list of items onto this adapter, using the new list. Calls notifyDataSetChanged
      *
-     * @param items the new items to set
-     */
-    override fun setNewList(items: List<Model>): ModelAdapter<Model, Item> {
-        return setNewList(items, false)
-    }
-
-    /**
-     * sets a complete new list of items onto this adapter, using the new list. Calls notifyDataSetChanged
-     *
      * @param list         the new items to set
      * @param retainFilter set to true if you want to keep the filter applied
      * @return this
      */
-    open fun setNewList(list: List<Model>, retainFilter: Boolean): ModelAdapter<Model, Item> {
+    override fun setNewList(list: List<Model>, retainFilter: Boolean): ModelAdapter<Model, Item> {
         val items = intercept(list)
 
         if (isUseIdDistributor) {
@@ -377,7 +368,7 @@ open class ModelAdapter<Model, Item : IItem<out RecyclerView.ViewHolder>>(
      * @param toPosition   the global position to which to move
      * @return this
      */
-    open fun move(fromPosition: Int, toPosition: Int): ModelAdapter<Model, Item> {
+    override fun move(fromPosition: Int, toPosition: Int): ModelAdapter<Model, Item> {
         itemList.move(fromPosition, toPosition, fastAdapter?.getPreItemCount(fromPosition) ?: 0)
         return this
     }

--- a/library-extensions-utils/src/main/java/com/mikepenz/fastadapter/adapters/FastItemAdapter.kt
+++ b/library-extensions-utils/src/main/java/com/mikepenz/fastadapter/adapters/FastItemAdapter.kt
@@ -4,6 +4,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.mikepenz.fastadapter.FastAdapter
 import com.mikepenz.fastadapter.IAdapter
 import com.mikepenz.fastadapter.IItem
+import com.mikepenz.fastadapter.IItemAdapter
 import com.mikepenz.fastadapter.adapters.ItemAdapter.Companion.items
 
 /**
@@ -14,38 +15,17 @@ typealias GenericFastItemAdapter = FastItemAdapter<IItem<out RecyclerView.ViewHo
 /**
  * Created by mikepenz on 18.01.16.
  */
-open class FastItemAdapter<Item : IItem<out RecyclerView.ViewHolder>> : FastAdapter<Item>() {
-    /**
-     * returns the internal created ItemAdapter
-     *
-     * @return the ItemAdapter used inside this FastItemAdapter
-     */
-    val itemAdapter: ItemAdapter<Item> = items()
-
+open class FastItemAdapter<Item : IItem<out RecyclerView.ViewHolder>>(
+        /**
+         * returns the internal created [ItemAdapter]
+         */
+        val itemAdapter: ItemAdapter<Item> = items()
+) : IItemAdapter<Item, Item> by itemAdapter, FastAdapter<Item>() {
     /**
      * @return the filter used to filter items
      */
     val itemFilter: ItemFilter<*, Item>
         get() = itemAdapter.itemFilter
-
-    /**
-     * @return the order of the items within the FastAdapter
-     */
-    val order: Int
-        get() = itemAdapter.order
-
-    /**
-     * @return the count of items within this adapter
-     */
-    val adapterItemCount: Int
-        get() = itemAdapter.adapterItemCount
-
-
-    /**
-     * @return the items within this adapter
-     */
-    val adapterItems: List<Item>
-        get() = itemAdapter.adapterItems
 
     /**
      * ctor
@@ -61,177 +41,9 @@ open class FastItemAdapter<Item : IItem<out RecyclerView.ViewHolder>> : FastAdap
      * @param useIdDistributor false if the IdDistributor shouldn't be used
      * @return this
      */
+    @Deprecated(message = "Use the isUseIdDistributor property getter", replaceWith = ReplaceWith("isUseIdDistributor"), level = DeprecationLevel.WARNING)
     open fun withUseIdDistributor(useIdDistributor: Boolean): FastItemAdapter<Item> {
         itemAdapter.isUseIdDistributor = useIdDistributor
-        return this
-    }
-
-    /**
-     * filters the items with the constraint using the provided Predicate
-     *
-     * @param constraint the string used to filter the list
-     */
-    open fun filter(constraint: CharSequence) {
-        itemAdapter.filter(constraint)
-    }
-
-    /**
-     * Searches for the given item and calculates its relative position
-     *
-     * @param item the item which is searched for
-     * @return the relative position
-     */
-    open fun getAdapterPosition(item: Item): Int {
-        return itemAdapter.getAdapterPosition(item)
-    }
-
-    /**
-     * returns the global position if the relative position within this adapter was given
-     *
-     * @param position the relative postion
-     * @return the global position
-     */
-    open fun getGlobalPosition(position: Int): Int {
-        return itemAdapter.getGlobalPosition(position)
-    }
-
-    /**
-     * @param position the relative position
-     * @return the item inside this adapter
-     */
-    open fun getAdapterItem(position: Int): Item {
-        return itemAdapter.getAdapterItem(position)
-    }
-
-    /**
-     * set a new list of items and apply it to the existing list (clear - add) for this adapter
-     *
-     * @param items the new items to set
-     */
-    open fun set(items: List<Item>): FastItemAdapter<Item> {
-        itemAdapter.set(items)
-        return this
-    }
-
-    /**
-     * sets a complete new list of items onto this adapter, using the new list. Calls notifyDataSetChanged
-     *
-     * @param items the new items to set
-     * @return this
-     */
-    open fun setNewList(items: List<Item>): FastItemAdapter<Item> {
-        itemAdapter.setNewList(items)
-        return this
-    }
-
-
-    /**
-     * sets a complete new list of items onto this adapter, using the new list. Calls notifyDataSetChanged
-     *
-     * @param items        the new items to set
-     * @param retainFilter set to true if you want to keep the filter applied
-     * @return this
-     */
-    open fun setNewList(items: List<Item>, retainFilter: Boolean): FastItemAdapter<Item> {
-        itemAdapter.setNewList(items, retainFilter)
-        return this
-    }
-
-    /**
-     * add an array of items to the end of the existing items
-     *
-     * @param items the items to add
-     */
-    @SafeVarargs
-    open fun add(vararg items: Item): FastItemAdapter<Item> {
-        itemAdapter.add(*items)
-        return this
-    }
-
-    /**
-     * add a list of items to the end of the existing items
-     *
-     * @param items the items to add
-     */
-    open fun add(items: List<Item>): FastItemAdapter<Item> {
-        itemAdapter.add(items)
-        return this
-    }
-
-    /**
-     * add an array of items at the given position within the existing items
-     *
-     * @param position the global position
-     * @param items    the items to add
-     */
-    @SafeVarargs
-    open fun add(position: Int, vararg items: Item): FastItemAdapter<Item> {
-        itemAdapter.add(position, *items)
-        return this
-    }
-
-    /**
-     * add a list of items at the given position within the existing items
-     *
-     * @param position the global position
-     * @param items    the items to add
-     */
-    open fun add(position: Int, items: List<Item>): FastItemAdapter<Item> {
-        itemAdapter.add(position, items)
-        return this
-    }
-
-    /**
-     * sets an item at the given position, overwriting the previous item
-     *
-     * @param position the global position
-     * @param item     the item to set
-     */
-    open operator fun set(position: Int, item: Item): FastItemAdapter<Item> {
-        itemAdapter[position] = item
-        return this
-    }
-
-    /**
-     * add an item at the end of the existing items
-     *
-     * @param item the item to add
-     */
-    open fun add(item: Item): FastItemAdapter<Item> {
-        itemAdapter.add(item)
-        return this
-    }
-
-    /**
-     * add an item at the given position within the existing icons
-     *
-     * @param position the global position
-     * @param item     the item to add
-     */
-    open fun add(position: Int, item: Item): FastItemAdapter<Item> {
-        itemAdapter.add(position, item)
-        return this
-    }
-
-    /**
-     * moves an item within the list from a position to a position
-     *
-     * @param fromPosition the position global from which we want to move
-     * @param toPosition   the global position to which to move
-     * @return this
-     */
-    open fun move(fromPosition: Int, toPosition: Int): FastItemAdapter<Item> {
-        itemAdapter.move(fromPosition, toPosition)
-        return this
-    }
-
-    /**
-     * removes an item at the given position within the existing icons
-     *
-     * @param position the global position
-     */
-    open fun remove(position: Int): FastItemAdapter<Item> {
-        itemAdapter.remove(position)
         return this
     }
 
@@ -241,16 +53,9 @@ open class FastItemAdapter<Item : IItem<out RecyclerView.ViewHolder>> : FastAdap
      * @param position  the global position
      * @param itemCount the count of items removed
      */
+    @Deprecated(message = "removeItemRange is deprecated", replaceWith = ReplaceWith("removeRange"), level = DeprecationLevel.WARNING)
     open fun removeItemRange(position: Int, itemCount: Int): FastItemAdapter<Item> {
         itemAdapter.removeRange(position, itemCount)
-        return this
-    }
-
-    /**
-     * removes all items of this adapter
-     */
-    open fun clear(): FastItemAdapter<Item> {
-        itemAdapter.clear()
         return this
     }
 


### PR DESCRIPTION
* use delegation for the `FastItemAdapter` to delegate calls to its `itemAdapter`
  * fixes https://github.com/mikepenz/FastAdapter/issues/781
* add missing functions to IItemAdapter interface

@AllanWang 