### PR TITLE
DSL for FastAdapter

### DIFF
--- a/library-core/src/main/java/com/mikepenz/fastadapter/FastAdapter.kt
+++ b/library-core/src/main/java/com/mikepenz/fastadapter/FastAdapter.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import androidx.collection.ArrayMap
 import androidx.recyclerview.widget.RecyclerView
 import com.mikepenz.fastadapter.adapters.ItemAdapter.Companion.items
+import com.mikepenz.fastadapter.dsl.FastAdapterDsl
 import com.mikepenz.fastadapter.extensions.ExtensionsFactories
 import com.mikepenz.fastadapter.listeners.*
 import com.mikepenz.fastadapter.utils.AdapterPredicate
@@ -35,6 +36,7 @@ typealias GenericFastAdapter = FastAdapter<GenericItem>
  *
  * @param <Item> Defines the type of items this `FastAdapter` manages (in case of multiple different types, use `IItem`)</Item>
  */
+@FastAdapterDsl
 open class FastAdapter<Item : GenericItem> : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     // we remember all adapters
@@ -165,13 +167,38 @@ open class FastAdapter<Item : GenericItem> : RecyclerView.Adapter<RecyclerView.V
      */
     open fun <A : IAdapter<Item>> addAdapter(index: Int, adapter: A): FastAdapter<Item> {
         adapters.add(index, adapter)
-        adapter.fastAdapter = this
-        adapter.mapPossibleTypes(adapter.adapterItems)
+        prepareAdapters()
+        return this
+    }
+
+    /**
+     * adds all new adapters at the end of the adapter list
+     *
+     * @param newAdapters the new adapters to be added
+     * @return this
+     */
+    open fun <A : IAdapter<Item>> addAdapters(newAdapters: List<A>): FastAdapter<Item> {
+        adapters.addAll(newAdapters as Collection<IAdapter<Item>>)
+        prepareAdapters()
+        return this
+    }
+
+    /**
+     * prepares all adapters for their usage. update the fastAdapter, ensure all types are mapped, and update the order for the adapter.
+     * It also updates the cached sizes.
+     */
+    private fun prepareAdapters(remapTypes: Boolean = true) {
         for (i in adapters.indices) {
-            adapters[i].order = i
+            adapters[i].apply {
+                this.fastAdapter = fastAdapter
+                this.order = i
+
+                if (remapTypes) {
+                    this.mapPossibleTypes(this.adapterItems)
+                }
+            }
         }
         cacheSizes()
-        return this
     }
 
     /**

--- a/library-core/src/main/java/com/mikepenz/fastadapter/FastAdapter.kt
+++ b/library-core/src/main/java/com/mikepenz/fastadapter/FastAdapter.kt
@@ -167,7 +167,7 @@ open class FastAdapter<Item : GenericItem> : RecyclerView.Adapter<RecyclerView.V
      */
     open fun <A : IAdapter<Item>> addAdapter(index: Int, adapter: A): FastAdapter<Item> {
         adapters.add(index, adapter)
-        prepareAdapters()
+        prepareAdapters(adapter)
         return this
     }
 
@@ -179,7 +179,9 @@ open class FastAdapter<Item : GenericItem> : RecyclerView.Adapter<RecyclerView.V
      */
     open fun <A : IAdapter<Item>> addAdapters(newAdapters: List<A>): FastAdapter<Item> {
         adapters.addAll(newAdapters as Collection<IAdapter<Item>>)
-        prepareAdapters()
+        newAdapters.forEach {
+            prepareAdapters(it)
+        }
         return this
     }
 
@@ -187,16 +189,11 @@ open class FastAdapter<Item : GenericItem> : RecyclerView.Adapter<RecyclerView.V
      * prepares all adapters for their usage. update the fastAdapter, ensure all types are mapped, and update the order for the adapter.
      * It also updates the cached sizes.
      */
-    private fun prepareAdapters(remapTypes: Boolean = true) {
+    private fun prepareAdapters(adapter: IAdapter<Item>) {
+        adapter.fastAdapter = this
+        adapter.mapPossibleTypes(adapter.adapterItems)
         for (i in adapters.indices) {
-            adapters[i].apply {
-                this.fastAdapter = fastAdapter
-                this.order = i
-
-                if (remapTypes) {
-                    this.mapPossibleTypes(this.adapterItems)
-                }
-            }
+            adapters[i].order = i
         }
         cacheSizes()
     }

--- a/library-core/src/main/java/com/mikepenz/fastadapter/adapters/ItemAdapter.kt
+++ b/library-core/src/main/java/com/mikepenz/fastadapter/adapters/ItemAdapter.kt
@@ -4,6 +4,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.mikepenz.fastadapter.GenericItem
 import com.mikepenz.fastadapter.IItem
 import com.mikepenz.fastadapter.IItemList
+import com.mikepenz.fastadapter.dsl.FastAdapterDsl
 import com.mikepenz.fastadapter.utils.InterceptorUtil
 
 /**
@@ -15,6 +16,7 @@ typealias GenericItemAdapter = ItemAdapter<IItem<out RecyclerView.ViewHolder>>
  * Created by mikepenz on 27.12.15.
  * A general ItemAdapter implementation based on the AbstractAdapter to speed up development for general items
  */
+@FastAdapterDsl
 open class ItemAdapter<Item : GenericItem> : ModelAdapter<Item, Item> {
 
     constructor() : super(InterceptorUtil.DEFAULT as (element: Item) -> Item?)

--- a/library-core/src/main/java/com/mikepenz/fastadapter/adapters/ModelAdapter.kt
+++ b/library-core/src/main/java/com/mikepenz/fastadapter/adapters/ModelAdapter.kt
@@ -2,6 +2,7 @@ package com.mikepenz.fastadapter.adapters
 
 import androidx.recyclerview.widget.RecyclerView
 import com.mikepenz.fastadapter.*
+import com.mikepenz.fastadapter.dsl.FastAdapterDsl
 import com.mikepenz.fastadapter.utils.AdapterPredicate
 import com.mikepenz.fastadapter.utils.DefaultItemList
 import com.mikepenz.fastadapter.utils.DefaultItemListImpl
@@ -18,6 +19,7 @@ typealias GenericModelAdapter<Model> = ModelAdapter<Model, IItem<out RecyclerVie
  * Created by mikepenz on 27.12.15.
  * A general ItemAdapter implementation based on the AbstractAdapter to speed up development for general items
  */
+@FastAdapterDsl
 open class ModelAdapter<Model, Item : GenericItem>(
         val itemList: IItemList<Item>, var interceptor: (element: Model) -> Item?
 ) : AbstractAdapter<Item>(), IItemAdapter<Model, Item> {

--- a/library-core/src/main/java/com/mikepenz/fastadapter/dsl/FastAdapterDsl.kt
+++ b/library-core/src/main/java/com/mikepenz/fastadapter/dsl/FastAdapterDsl.kt
@@ -10,15 +10,15 @@ import com.mikepenz.fastadapter.adapters.ModelAdapter
 @DslMarker
 annotation class FastAdapterDsl
 
-fun genericfastadapter(block: (FastAdapter<GenericItem>).() -> Unit): FastAdapter<GenericItem> {
+inline fun genericfastadapter(block: (FastAdapter<GenericItem>).() -> Unit): FastAdapter<GenericItem> {
     return FastAdapter<GenericItem>().apply(block)
 }
 
-fun <Item : GenericItem> fastadapter(block: (FastAdapter<Item>).() -> Unit): FastAdapter<Item> {
+inline fun <Item : GenericItem> fastadapter(block: (FastAdapter<Item>).() -> Unit): FastAdapter<Item> {
     return FastAdapter<Item>().apply(block)
 }
 
-fun <ParentItem : GenericItem, ChildItem : ParentItem> FastAdapter<ParentItem>.itemAdapter(block: ItemAdapter<ChildItem>.() -> Unit) {
+inline fun <ParentItem : GenericItem, ChildItem : ParentItem> FastAdapter<ParentItem>.itemAdapter(block: ItemAdapter<ChildItem>.() -> Unit) {
     addAdapters(listOf(ItemAdapter<ChildItem>().apply(block) as IAdapter<ParentItem>))
 }
 

--- a/library-core/src/main/java/com/mikepenz/fastadapter/dsl/FastAdapterDsl.kt
+++ b/library-core/src/main/java/com/mikepenz/fastadapter/dsl/FastAdapterDsl.kt
@@ -11,11 +11,11 @@ import com.mikepenz.fastadapter.adapters.ModelAdapter
 annotation class FastAdapterDsl
 
 fun genericfastadapter(block: (FastAdapter<GenericItem>).() -> Unit): FastAdapter<GenericItem> {
-    return FastAdapter<GenericItem>().apply { block(this) }
+    return FastAdapter<GenericItem>().apply(block)
 }
 
 fun <Item : GenericItem> fastadapter(block: (FastAdapter<Item>).() -> Unit): FastAdapter<Item> {
-    return FastAdapter<Item>().apply { block(this) }
+    return FastAdapter<Item>().apply(block)
 }
 
 fun <ParentItem : GenericItem, ChildItem : ParentItem> FastAdapter<ParentItem>.itemAdapter(block: ItemAdapter<ChildItem>.() -> Unit) {

--- a/library-core/src/main/java/com/mikepenz/fastadapter/dsl/FastAdapterDsl.kt
+++ b/library-core/src/main/java/com/mikepenz/fastadapter/dsl/FastAdapterDsl.kt
@@ -1,0 +1,31 @@
+package com.mikepenz.fastadapter.dsl
+
+import com.mikepenz.fastadapter.FastAdapter
+import com.mikepenz.fastadapter.GenericItem
+import com.mikepenz.fastadapter.IAdapter
+import com.mikepenz.fastadapter.IItemList
+import com.mikepenz.fastadapter.adapters.ItemAdapter
+import com.mikepenz.fastadapter.adapters.ModelAdapter
+
+@DslMarker
+annotation class FastAdapterDsl
+
+fun genericfastadapter(block: (FastAdapter<GenericItem>).() -> Unit): FastAdapter<GenericItem> {
+    return FastAdapter<GenericItem>().apply { block(this) }
+}
+
+fun <Item : GenericItem> fastadapter(block: (FastAdapter<Item>).() -> Unit): FastAdapter<Item> {
+    return FastAdapter<Item>().apply { block(this) }
+}
+
+fun <ParentItem : GenericItem, ChildItem : ParentItem> FastAdapter<ParentItem>.itemAdapter(block: ItemAdapter<ChildItem>.() -> Unit) {
+    addAdapters(listOf(ItemAdapter<ChildItem>().apply(block) as IAdapter<ParentItem>))
+}
+
+fun <Model, ParentItem : GenericItem, ChildItem : ParentItem> FastAdapter<ParentItem>.modelAdapter(interceptor: (element: Model) -> ChildItem?, block: ModelAdapter<Model, ChildItem>.() -> Unit) {
+    addAdapters(listOf(ModelAdapter<Model, ChildItem>(interceptor).apply(block) as ModelAdapter<Model, ParentItem>))
+}
+
+fun <Model, ParentItem : GenericItem, ChildItem : ParentItem> FastAdapter<ParentItem>.modelAdapter(itemList: IItemList<ChildItem>, interceptor: (element: Model) -> ChildItem?, block: ModelAdapter<Model, ChildItem>.() -> Unit) {
+    addAdapters(listOf(ModelAdapter(itemList, interceptor).apply(block) as ModelAdapter<Model, ParentItem>))
+}

--- a/library-core/src/main/java/com/mikepenz/fastadapter/select/SelectExtension.kt
+++ b/library-core/src/main/java/com/mikepenz/fastadapter/select/SelectExtension.kt
@@ -5,6 +5,7 @@ import android.view.MotionEvent
 import android.view.View
 import androidx.collection.ArraySet
 import com.mikepenz.fastadapter.*
+import com.mikepenz.fastadapter.dsl.FastAdapterDsl
 import com.mikepenz.fastadapter.extensions.ExtensionsFactories
 import com.mikepenz.fastadapter.utils.AdapterPredicate
 import java.util.*
@@ -19,8 +20,17 @@ fun <Item : GenericItem> FastAdapter<Item>.getSelectExtension(): SelectExtension
 }
 
 /**
+ * Extension method to retrieve or create the SelectExtension from the current FastAdapter.
+ * This will return a non null variant and fail if something terrible happens.
+ */
+fun <Item : GenericItem> FastAdapter<Item>.selectExtension(block: SelectExtension<Item>.() -> Unit) {
+    getSelectExtension().apply(block)
+}
+
+/**
  * Created by mikepenz on 04/06/2017.
  */
+@FastAdapterDsl
 class SelectExtension<Item : GenericItem>(private val fastAdapter: FastAdapter<Item>) : IAdapterExtension<Item> {
 
     // if enabled we will select the item via a notifyItemChanged -> will animate with the Animator

--- a/library-extensions-expandable/src/main/java/com/mikepenz/fastadapter/expandable/ExpandableExtension.kt
+++ b/library-extensions-expandable/src/main/java/com/mikepenz/fastadapter/expandable/ExpandableExtension.kt
@@ -15,9 +15,17 @@ import java.util.*
  * Extension method to retrieve or create the ExpandableExtension from the current FastAdapter
  * This will return a non null variant and fail
  */
-fun <Item : IItem<*>> FastAdapter<Item>.getExpandableExtension(): ExpandableExtension<Item> {
+fun <Item : GenericItem> FastAdapter<Item>.getExpandableExtension(): ExpandableExtension<Item> {
     ExpandableExtension.toString() // enforces the vm to lead in the companion object
     return requireOrCreateExtension()
+}
+
+/**
+ * Extension method to retrieve or create the ExpandableExtension from the current FastAdapter
+ * This will return a non null variant and fail
+ */
+fun <Item : GenericItem> FastAdapter<Item>.expandableExtension(block: ExpandableExtension<Item>.() -> Unit) {
+    getExpandableExtension().apply(block)
 }
 
 /**


### PR DESCRIPTION
* introduce a new proposed DSL to the FastAdapter to simplify setup

The current DSL would look like:

```kotlin
fastadapter<GenericItem> {
    selectExtension {
        allowDeselection = false
    }
    expandableExtension {
        isOnlyOneExpandedItem = true
    }
    itemAdapter<GenericItem, SimpleImageItem> {

    }
    itemAdapter {

    }
    modelAdapter({ it: Number -> SimpleImageItem() }) {

    }
}


fastadapter<SimpleImageItem> {
    itemAdapter {

    }
}

genericfastadapter {
    itemAdapter {

    }
}
``` 

Image to see the types resolved:
![image](https://user-images.githubusercontent.com/1476232/59966103-846c7e80-9517-11e9-8b47-b96a0e6f0092.png)


cc @AllanWang
