### PR TITLE
Added LayoutContainer in FastAdapter.ViewHolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ implementation "com.google.android.material:material:${androidX}"
 implementation "com.mikepenz:materialize:${latestVersion}" // at least 1.2.0
 ```
 
+If unable to use Android Extensions to access views in ViewHolder, add line below in app gradle.
+```gradle
+android{
+    ...
+    androidExtensions {
+        experimental = true
+    }
+}
+
+```
+
 ## v4.x.y
 > Major release, migrates fully to Kotlin. Check out the changelog or the [MIGRATION GUIDE](https://github.com/mikepenz/FastAdapter/blob/develop/MIGRATION.md for more details
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'realm-android'
 //wrap with try and catch so the build is working even if the signing stuff is missing
@@ -40,6 +40,9 @@ android {
             zipAlignEnabled true
             minifyEnabled false
         }
+    }
+    androidExtensions {
+        experimental = true
     }
     lintOptions {
         abortOnError false

--- a/library-core/build.gradle
+++ b/library-core/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion setup.compileSdk
@@ -30,6 +31,9 @@ android {
         unitTests {
             includeAndroidResources = true
         }
+    }
+    androidExtensions {
+        experimental = true
     }
     // specify the artifactId as module-name for kotlin
     kotlinOptions.freeCompilerArgs += ["-module-name", POM_ARTIFACT_ID]

--- a/library-core/src/main/java/com/mikepenz/fastadapter/FastAdapter.kt
+++ b/library-core/src/main/java/com/mikepenz/fastadapter/FastAdapter.kt
@@ -16,6 +16,7 @@ import com.mikepenz.fastadapter.utils.AdapterPredicate
 import com.mikepenz.fastadapter.utils.DefaultTypeInstanceCache
 import com.mikepenz.fastadapter.utils.Triple
 import com.mikepenz.fastadapter.utils.attachToView
+import kotlinx.android.extensions.LayoutContainer
 import java.util.*
 import kotlin.math.min
 
@@ -845,7 +846,13 @@ open class FastAdapter<Item : GenericItem> : RecyclerView.Adapter<RecyclerView.V
      *
      * @param <Item>
     </Item> */
-    abstract class ViewHolder<Item : GenericItem>(itemView: View) : RecyclerView.ViewHolder(itemView) {
+    abstract class ViewHolder<Item : GenericItem>(itemView: View) : RecyclerView.ViewHolder(itemView), LayoutContainer {
+
+        /**
+         * The container view that contains cached Ids.
+         * */
+        override val containerView: View?
+            get() = itemView
 
         /**
          * binds the data of this item onto the viewHolder


### PR DESCRIPTION
Added LayoutContainer in order to utilise Android Extensions to access and cache views.

Ref: https://proandroiddev.com/kotlin-android-extensions-using-view-binding-the-right-way-707cd0c9e648