### PR TITLE
Make OnBindViewHolderListenerImpl and OnCreateViewHolderListenerImpl open

### DIFF
--- a/library-core/src/main/java/com/mikepenz/fastadapter/listeners/OnBindViewHolderListenerImpl.kt
+++ b/library-core/src/main/java/com/mikepenz/fastadapter/listeners/OnBindViewHolderListenerImpl.kt
@@ -7,7 +7,7 @@ import com.mikepenz.fastadapter.GenericItem
 import com.mikepenz.fastadapter.IItem
 import com.mikepenz.fastadapter.R
 
-class OnBindViewHolderListenerImpl<Item : GenericItem> : OnBindViewHolderListener {
+open class OnBindViewHolderListenerImpl<Item : GenericItem> : OnBindViewHolderListener {
     /**
      * is called in onBindViewHolder to bind the data on the ViewHolder
      *

--- a/library-core/src/main/java/com/mikepenz/fastadapter/listeners/OnCreateViewHolderListenerImpl.kt
+++ b/library-core/src/main/java/com/mikepenz/fastadapter/listeners/OnCreateViewHolderListenerImpl.kt
@@ -10,7 +10,7 @@ import com.mikepenz.fastadapter.utils.bind
 /**
  * default implementation of the OnCreateViewHolderListener
  */
-class OnCreateViewHolderListenerImpl<Item : GenericItem> : OnCreateViewHolderListener<Item> {
+open class OnCreateViewHolderListenerImpl<Item : GenericItem> : OnCreateViewHolderListener<Item> {
     /**
      * is called inside the onCreateViewHolder method and creates the viewHolder based on the provided viewTyp
      *
@@ -29,7 +29,7 @@ class OnCreateViewHolderListenerImpl<Item : GenericItem> : OnCreateViewHolderLis
      * @return the viewHolder given as param
      */
     override fun onPostCreateViewHolder(fastAdapter: FastAdapter<Item>, viewHolder: RecyclerView.ViewHolder, typeInstance: Item): RecyclerView.ViewHolder {
-        fastAdapter.eventHooks?.bind(viewHolder)
+        fastAdapter.eventHooks.bind(viewHolder)
         //check if the item implements hookable and contains event hooks
         (typeInstance as? IHookable<*>)?.eventHooks?.bind(viewHolder)
         return viewHolder


### PR DESCRIPTION
Currently these classes are final, which breaks objects extending them from previous versions of FastAdapter