### PR TITLE
Allow swipes without setting "leave-behind" drawables

### DIFF
--- a/library-extensions-swipe/src/main/java/com/mikepenz/fastadapter/swipe/SimpleSwipeCallback.kt
+++ b/library-extensions-swipe/src/main/java/com/mikepenz/fastadapter/swipe/SimpleSwipeCallback.kt
@@ -57,11 +57,13 @@ class SimpleSwipeCallback @JvmOverloads constructor(private val itemSwipeCallbac
 
     fun withBackgroundSwipeLeft(@ColorInt bgColor: Int): SimpleSwipeCallback {
         bgColorLeft = bgColor
+        setDefaultSwipeDirs(swipeDirs or ItemTouchHelper.LEFT)
         return this
     }
 
     fun withBackgroundSwipeRight(@ColorInt bgColor: Int): SimpleSwipeCallback {
         bgColorRight = bgColor
+        setDefaultSwipeDirs(swipeDirs or ItemTouchHelper.RIGHT)
         return this
     }
 

--- a/library-extensions-utils/src/main/java/com/mikepenz/fastadapter/swipe_drag/SimpleSwipeDragCallback.kt
+++ b/library-extensions-utils/src/main/java/com/mikepenz/fastadapter/swipe_drag/SimpleSwipeDragCallback.kt
@@ -54,11 +54,13 @@ class SimpleSwipeDragCallback @JvmOverloads constructor(itemTouchCallback: ItemT
     }
 
     fun withBackgroundSwipeLeft(@ColorInt bgColor: Int): SimpleSwipeDragCallback {
+        setDefaultSwipeDirs(defaultSwipeDirs or ItemTouchHelper.LEFT)
         simpleSwipeCallback.withBackgroundSwipeLeft(bgColor)
         return this
     }
 
     fun withBackgroundSwipeRight(@ColorInt bgColor: Int): SimpleSwipeDragCallback {
+        setDefaultSwipeDirs(defaultSwipeDirs or ItemTouchHelper.RIGHT)
         simpleSwipeCallback.withBackgroundSwipeRight(bgColor)
         return this
     }


### PR DESCRIPTION
At the moment you must specify a drawable on the `SimpleSwipeCallback` for swipe to be enabled. I have changed this so if either a background colour or a "leave-behind" drawable is set, swipe is enabled.