### PR TITLE
Fix #843 -> PagedItemList should support placeholders

### DIFF
--- a/library-core/src/main/java/com/mikepenz/fastadapter/IItemList.kt
+++ b/library-core/src/main/java/com/mikepenz/fastadapter/IItemList.kt
@@ -32,5 +32,5 @@ interface IItemList<Item : GenericItem> {
 
     fun addAll(position: Int, items: List<Item>, preItemCount: Int)
 
-    operator fun get(position: Int): Item
+    operator fun get(position: Int): Item?
 }

--- a/library-core/src/main/java/com/mikepenz/fastadapter/adapters/ModelAdapter.kt
+++ b/library-core/src/main/java/com/mikepenz/fastadapter/adapters/ModelAdapter.kt
@@ -154,7 +154,7 @@ open class ModelAdapter<Model, Item : GenericItem>(
      * @return the item inside this adapter
      */
     override fun getAdapterItem(position: Int): Item {
-        return itemList[position]
+        return itemList[position] ?: throw java.lang.RuntimeException("A normal ModelAdapter does not allow null items.")
     }
 
     /**

--- a/library-extensions-paged/src/main/java/com/mikepenz/fastadapter/paged/PagedModelAdapter.kt
+++ b/library-extensions-paged/src/main/java/com/mikepenz/fastadapter/paged/PagedModelAdapter.kt
@@ -6,6 +6,7 @@ import androidx.recyclerview.widget.AsyncDifferConfig
 import androidx.recyclerview.widget.ListUpdateCallback
 import com.mikepenz.fastadapter.*
 import com.mikepenz.fastadapter.dsl.FastAdapterDsl
+import com.mikepenz.fastadapter.paged.PagedItemListImpl.Companion.getDefaultPlaceholderInterceptor
 import com.mikepenz.fastadapter.utils.DefaultItemList
 
 // Notify user that the DSL is currently experimental
@@ -25,9 +26,10 @@ typealias GenericPagedModelAdapter<Model> = PagedModelAdapter<Model, GenericItem
 @FastAdapterDsl
 open class PagedModelAdapter<Model, Item : GenericItem>(
         asyncDifferConfig: AsyncDifferConfig<Model>,
+        placeholderInterceptor: (position: Int) -> Item = getDefaultPlaceholderInterceptor(),
         var interceptor: (element: Model) -> Item?
 ) : AbstractAdapter<Item>(), IItemAdapter<Model, Item>, ListUpdateCallback {
-    val itemList: PagedItemListImpl<Model, Item> = PagedItemListImpl(this, asyncDifferConfig, interceptor)
+    val itemList: PagedItemListImpl<Model, Item> = PagedItemListImpl(this, asyncDifferConfig, placeholderInterceptor, interceptor)
 
     override var idDistributor: IIdDistributor<Item> = IIdDistributor.DEFAULT as IIdDistributor<Item>
 
@@ -358,8 +360,8 @@ open class PagedModelAdapter<Model, Item : GenericItem>(
          * @return a new ItemAdapter
          */
         @JvmStatic
-        fun <Model, Item : GenericItem> models(asyncDifferConfig: AsyncDifferConfig<Model>, interceptor: (element: Model) -> Item?): PagedModelAdapter<Model, Item> {
-            return PagedModelAdapter(asyncDifferConfig, interceptor)
+        fun <Model, Item : GenericItem> models(asyncDifferConfig: AsyncDifferConfig<Model>, placeholderInterceptor: (position: Int) -> Item, interceptor: (element: Model) -> Item?): PagedModelAdapter<Model, Item> {
+            return PagedModelAdapter(asyncDifferConfig, placeholderInterceptor, interceptor)
         }
     }
 }


### PR DESCRIPTION
* a PagedListAdapter is allowed to have placeholders. those placeholders are defined as null
  * introduce a interceptor to specify what item the adapter should provide if an element is still a placeholder.
  * FIX https://github.com/mikepenz/FastAdapter/issues/843