### PR TITLE
Rename parameters in AbstractBindingItem to match the type

### DIFF
--- a/library-extensions-binding/src/main/java/com/mikepenz/fastadapter/binding/AbstractBindingItem.kt
+++ b/library-extensions-binding/src/main/java/com/mikepenz/fastadapter/binding/AbstractBindingItem.kt
@@ -25,21 +25,21 @@ abstract class AbstractBindingItem<Binding : ViewBinding> : BaseItem<BindingView
         unbindView(holder.binding)
     }
 
-    open fun unbindView(holder: Binding) {}
+    open fun unbindView(binding: Binding) {}
 
     override fun attachToWindow(holder: BindingViewHolder<Binding>) {
         super.attachToWindow(holder)
         attachToWindow(holder.binding)
     }
 
-    open fun attachToWindow(holder: Binding) {}
+    open fun attachToWindow(binding: Binding) {}
 
     override fun detachFromWindow(holder: BindingViewHolder<Binding>) {
         super.detachFromWindow(holder)
         detachFromWindow(holder.binding)
     }
 
-    open fun detachFromWindow(holder: Binding) {}
+    open fun detachFromWindow(binding: Binding) {}
 
     /**
      * This method is called by generateView(Context ctx), generateView(Context ctx, ViewGroup parent) and getViewHolder(ViewGroup parent)


### PR DESCRIPTION
Rename parameters in AbstractBindingItem to match the type for the newly added Binding functions.