### PR TITLE
Add expandAllOnPath method to ExpandableExtension

### DIFF
--- a/app/src/main/java/com/mikepenz/fastadapter/app/ExpandableSampleActivity.kt
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/ExpandableSampleActivity.kt
@@ -41,6 +41,8 @@ class ExpandableSampleActivity : AppCompatActivity() {
         rv.itemAnimator = SlideDownAlphaAnimator()
         rv.adapter = fastItemAdapter
 
+        var itemToBeExpanded: SimpleSubExpandableItem? = null
+
         //fill with some sample data
         val items = ArrayList<GenericItem>()
         val identifier = AtomicLong(1)
@@ -74,14 +76,22 @@ class ExpandableSampleActivity : AppCompatActivity() {
                         val subSubSubItem = SimpleSubExpandableItem()
                         subSubSubItem.withName("---- SubSubSubTest $iiii").identifier = identifier.getAndIncrement()
                         subSubSubItems.add(subSubSubItem)
+
+                        //save 7th item just to demonstrate how expandAllOnPath works
+                        if (identifier.get() == 7L) {
+                            itemToBeExpanded = subSubSubItem
+                        }
                     }
                     subSubItem.subItems.addAll(subSubSubItems)
+                    subSubItem.subItems.forEach { it.parent = subSubItem }
                     subSubItems.add(subSubItem)
                 }
                 subItem.subItems.addAll(subSubItems)
+                subItem.subItems.forEach { it.parent = subItem }
                 subItems.add(subItem)
             }
             parent.subItems.addAll(subItems)
+            parent.subItems.forEach { it.parent = parent }
             items.add(parent)
         }
         fastItemAdapter.add(items)
@@ -92,6 +102,9 @@ class ExpandableSampleActivity : AppCompatActivity() {
         //set the back arrow in the toolbar
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         supportActionBar?.setHomeButtonEnabled(false)
+
+        //expand the whole path for the previously selected item
+        fastItemAdapter.getExpandableExtension().expandAllOnPath(itemToBeExpanded)
     }
 
     override fun onSaveInstanceState(_outState: Bundle) {

--- a/library-extensions-expandable/src/main/java/com/mikepenz/fastadapter/expandable/ExpandableExtension.kt
+++ b/library-extensions-expandable/src/main/java/com/mikepenz/fastadapter/expandable/ExpandableExtension.kt
@@ -411,6 +411,25 @@ class ExpandableExtension<Item : GenericItem>(private val fastAdapter: FastAdapt
     }
 
     /**
+     * Expand all items on a path from the root to a certain item
+     *
+     * @param item              item to be expanded
+     * @param notifyItemChanged true if we need to call notifyItemChanged. DEFAULT: false
+     */
+    @JvmOverloads
+    fun expandAllOnPath(item: IExpandable<*>?, notifyItemChanged: Boolean = false) {
+        val parents = getExpandableParents(item ?: return)
+
+        parents.forEach { expand(fastAdapter.getPosition(it.identifier)) }
+
+        //we need to notify to get the correct drawable if there is one showing the current state
+        if (notifyItemChanged) {
+            val position = fastAdapter.getPosition(item.identifier)
+            fastAdapter.notifyItemChanged(position)
+        }
+    }
+
+    /**
      * Opens the expandable item at the given position with parents who contains this item
      *
      * @param position          the global position
@@ -447,6 +466,12 @@ class ExpandableExtension<Item : GenericItem>(private val fastAdapter: FastAdapt
     /** Walks through the parents tree while parents are non-null and parents are IExpandable */
     private fun getExpandableParents(position: Int): List<IExpandable<*>> {
         val expandable = fastAdapter.getItem(position) as? IExpandable<*> ?: return emptyList()
+
+        return getExpandableParents(expandable)
+    }
+
+    /** Walks through the parents tree while parents are non-null and parents are IExpandable */
+    private fun getExpandableParents(expandable: IExpandable<*>): List<IExpandable<*>> {
 
         // walk through the parents tree
         val parents = mutableListOf<IExpandable<*>>()


### PR DESCRIPTION
#911 Added method for expanding all items on a path. Updated the example just to show how to use this method.

I'm not sure what are use cases of using similar method `expandIncludeParents`. I mean, is there any way to get a position of a collapsed element?