### PR TITLE
Swipe events for SwipeDrawer behaviour

### DIFF
--- a/app/src/main/java/com/mikepenz/fastadapter/app/SwipeDrawerListActivity.kt
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/SwipeDrawerListActivity.kt
@@ -58,7 +58,6 @@ class SwipeDrawerListActivity : AppCompatActivity(), ItemTouchCallback, SimpleSw
     }
 
     private fun share(item: SwipeableDrawerItem) {
-        item.shareAction = null
         val position12 = fastItemDrawerAdapter.getAdapterPosition(item)
         if (position12 != RecyclerView.NO_POSITION) {
             // Do something intelligent here
@@ -200,6 +199,10 @@ class SwipeDrawerListActivity : AppCompatActivity(), ItemTouchCallback, SimpleSw
         var directionStr = ""
         if (ItemTouchHelper.LEFT == direction) directionStr = "left"
         else if (ItemTouchHelper.RIGHT == direction) directionStr = "right"
-        Toast.makeText(this, "Item $position swiped $directionStr", Toast.LENGTH_SHORT).show()
+        println("Item $position swiped $directionStr")
+    }
+
+    override fun itemUnswiped(position: Int) {
+        println("Item $position unswiped")
     }
 }

--- a/app/src/main/java/com/mikepenz/fastadapter/app/SwipeDrawerListActivity.kt
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/SwipeDrawerListActivity.kt
@@ -17,6 +17,7 @@ import com.mikepenz.fastadapter.app.adapters.IDraggableViewHolder
 import com.mikepenz.fastadapter.app.items.SwipeableDrawerItem
 import com.mikepenz.fastadapter.drag.ItemTouchCallback
 import com.mikepenz.fastadapter.drag.SimpleDragCallback
+import com.mikepenz.fastadapter.swipe.SimpleSwipeDrawerCallback
 import com.mikepenz.fastadapter.swipe_drag.SimpleSwipeDrawerDragCallback
 import com.mikepenz.fastadapter.utils.DragDropUtil
 import com.mikepenz.iconics.IconicsDrawable
@@ -27,7 +28,7 @@ import io.reactivex.functions.Consumer
 import kotlinx.android.synthetic.main.activity_sample.*
 import java.util.*
 
-class SwipeDrawerListActivity : AppCompatActivity(), ItemTouchCallback {
+class SwipeDrawerListActivity : AppCompatActivity(), ItemTouchCallback, SimpleSwipeDrawerCallback.ItemSwipeCallback {
 
     //save our FastAdapter
     private lateinit var fastItemDrawerAdapter: FastItemAdapter<SwipeableDrawerItem>
@@ -108,7 +109,8 @@ class SwipeDrawerListActivity : AppCompatActivity(), ItemTouchCallback {
         //and add swipe as well
         touchCallback = SimpleSwipeDrawerDragCallback(
                 this,
-                ItemTouchHelper.LEFT)
+                ItemTouchHelper.LEFT,
+                this)
                 .withNotifyAllDrops(true)
                 .withSwipeLeft(80) // Width of delete button
                 .withSwipeRight(160) // Width of archive and share buttons
@@ -192,5 +194,12 @@ class SwipeDrawerListActivity : AppCompatActivity(), ItemTouchCallback {
 
     companion object {
         private val ALPHABET = arrayOf("A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z")
+    }
+
+    override fun itemSwiped(position: Int, direction: Int) {
+        var directionStr = ""
+        if (ItemTouchHelper.LEFT == direction) directionStr = "left"
+        else if (ItemTouchHelper.RIGHT == direction) directionStr = "right"
+        Toast.makeText(this, "Item $position swiped $directionStr", Toast.LENGTH_SHORT).show()
     }
 }

--- a/library-extensions-swipe/src/main/java/com/mikepenz/fastadapter/swipe/SimpleSwipeDrawerCallback.kt
+++ b/library-extensions-swipe/src/main/java/com/mikepenz/fastadapter/swipe/SimpleSwipeDrawerCallback.kt
@@ -15,7 +15,7 @@ import com.mikepenz.fastadapter.IItem
 /**
  * Created by Robb on 2020-07-04.
  */
-class SimpleSwipeDrawerCallback @JvmOverloads constructor(private val swipeDirs: Int = ItemTouchHelper.LEFT) : ItemTouchHelper.SimpleCallback(0, swipeDirs) {
+class SimpleSwipeDrawerCallback @JvmOverloads constructor(private val swipeDirs: Int = ItemTouchHelper.LEFT, private val itemSwipeCallback: ItemSwipeCallback? = null) : ItemTouchHelper.SimpleCallback(0, swipeDirs) {
 
     // Swipe movement control
     private var sensitivityFactor = 1f
@@ -27,6 +27,16 @@ class SimpleSwipeDrawerCallback @JvmOverloads constructor(private val swipeDirs:
     // Indicates whether the touchTransmitter has been set on the RecyclerView
     private var touchTransmitterSet = false
 
+    interface ItemSwipeCallback {
+
+        /**
+         * Called when an item has been swiped
+         *
+         * @param position  position of item in the adapter
+         * @param direction direction the item was swiped
+         */
+        fun itemSwiped(position: Int, direction: Int)
+    }
 
     /**
      * Enable swipe to the left until the given width has been reached
@@ -71,7 +81,12 @@ class SimpleSwipeDrawerCallback @JvmOverloads constructor(private val swipeDirs:
     }
 
     override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
-        // Not used
+        viewHolder.itemView.translationX = 0f
+        viewHolder.itemView.translationY = 0f
+        val position = viewHolder.adapterPosition
+        if (position != RecyclerView.NO_POSITION) {
+            itemSwipeCallback?.itemSwiped(position, direction)
+        }
     }
 
     override fun onMove(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder, target: RecyclerView.ViewHolder): Boolean {

--- a/library-extensions-swipe/src/main/java/com/mikepenz/fastadapter/swipe/SimpleSwipeDrawerCallback.kt
+++ b/library-extensions-swipe/src/main/java/com/mikepenz/fastadapter/swipe/SimpleSwipeDrawerCallback.kt
@@ -126,7 +126,7 @@ class SimpleSwipeDrawerCallback @JvmOverloads constructor(private val swipeDirs:
      * Hack to force-transmit click events to the first visible View at the clicked coordinates
      * [< swiped area ] exposed sublayer ]
      * Android default touch event mechanisms don't transmit these events to the sublayer :
-     * any click on the exposed surface just swipe the item back to where it came
+     * any click on the exposed surface just swipes the item back to where it came
      */
     class RecyclerTouchTransmitter : View.OnTouchListener {
 

--- a/library-extensions-swipe/src/main/java/com/mikepenz/fastadapter/swipe/SimpleSwipeDrawerCallback.kt
+++ b/library-extensions-swipe/src/main/java/com/mikepenz/fastadapter/swipe/SimpleSwipeDrawerCallback.kt
@@ -30,7 +30,7 @@ class SimpleSwipeDrawerCallback @JvmOverloads constructor(private val swipeDirs:
     // States of swiped items
     //  Key = item position
     //  Value = swiped direction (see {@link ItemTouchHelper})
-    private val swipedStates = HashMap<Int,Int>()
+    private val swipedStates = HashMap<Int, Int>()
 
     interface ItemSwipeCallback {
 
@@ -96,7 +96,7 @@ class SimpleSwipeDrawerCallback @JvmOverloads constructor(private val swipeDirs:
         viewHolder.itemView.translationX = 0f
         viewHolder.itemView.translationY = 0f
         val position = viewHolder.adapterPosition
-        if (position != RecyclerView.NO_POSITION && (!swipedStates.containsKey(position) || swipedStates[position] != direction) ) {
+        if (position != RecyclerView.NO_POSITION && (!swipedStates.containsKey(position) || swipedStates[position] != direction)) {
             itemSwipeCallback?.itemSwiped(position, direction)
             swipedStates[position] = direction
         }

--- a/library-extensions-swipe/src/main/java/com/mikepenz/fastadapter/swipe/SimpleSwipeDrawerCallback.kt
+++ b/library-extensions-swipe/src/main/java/com/mikepenz/fastadapter/swipe/SimpleSwipeDrawerCallback.kt
@@ -93,8 +93,6 @@ class SimpleSwipeDrawerCallback @JvmOverloads constructor(private val swipeDirs:
     }
 
     override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
-        viewHolder.itemView.translationX = 0f
-        viewHolder.itemView.translationY = 0f
         val position = viewHolder.adapterPosition
         if (position != RecyclerView.NO_POSITION && (!swipedStates.containsKey(position) || swipedStates[position] != direction)) {
             itemSwipeCallback?.itemSwiped(position, direction)

--- a/library-extensions-swipe/src/main/java/com/mikepenz/fastadapter/swipe/SimpleSwipeDrawerCallback.kt
+++ b/library-extensions-swipe/src/main/java/com/mikepenz/fastadapter/swipe/SimpleSwipeDrawerCallback.kt
@@ -27,18 +27,26 @@ class SimpleSwipeDrawerCallback @JvmOverloads constructor(private val swipeDirs:
     // Indicates whether the touchTransmitter has been set on the RecyclerView
     private var touchTransmitterSet = false
 
+    // States of swiped items
+    //  Key = item position
+    //  Value = swiped direction (see {@link ItemTouchHelper})
     private val swipedStates = HashMap<Int,Int>()
 
     interface ItemSwipeCallback {
 
         /**
-         * Called when an drawer has been swiped
+         * Called when a drawer has been swiped
          *
          * @param position  position of item in the adapter
-         * @param direction direction the item where the drawer was swiped
+         * @param direction direction the item where the drawer was swiped (see {@link ItemTouchHelper})
          */
         fun itemSwiped(position: Int, direction: Int)
 
+        /**
+         * Called when a drawer has been un-swiped (= returns to its default position)
+         *
+         * @param position  position of item in the adapter
+         */
         fun itemUnswiped(position: Int)
     }
 
@@ -115,11 +123,10 @@ class SimpleSwipeDrawerCallback @JvmOverloads constructor(private val swipeDirs:
         if (position == RecyclerView.NO_POSITION) return
 
         if (actionState == ItemTouchHelper.ACTION_STATE_SWIPE) {
-            println(">> dX $dX")
             // Careful, dX is not the delta of user's movement, it's the new offset of the swiped view's left side !
             val isLeftArea = dX < 0
 
-            // Update swiped state
+            // If unswiped, fire event and update swiped state
             if (0f == dX && swipedStates.containsKey(position)) {
                 itemSwipeCallback?.itemUnswiped(viewHolder.adapterPosition)
                 swipedStates.remove(position)

--- a/library-extensions-utils/src/main/java/com/mikepenz/fastadapter/swipe_drag/SimpleSwipeDrawerDragCallback.kt
+++ b/library-extensions-utils/src/main/java/com/mikepenz/fastadapter/swipe_drag/SimpleSwipeDrawerDragCallback.kt
@@ -14,14 +14,15 @@ import com.mikepenz.fastadapter.swipe.SimpleSwipeDrawerCallback
  */
 class SimpleSwipeDrawerDragCallback @JvmOverloads constructor(
         itemTouchCallback: ItemTouchCallback,
-        swipeDirs: Int = ItemTouchHelper.LEFT) : SimpleDragCallback(itemTouchCallback) {
+        swipeDirs: Int = ItemTouchHelper.LEFT,
+        itemSwipeCallback: SimpleSwipeDrawerCallback.ItemSwipeCallback? = null) : SimpleDragCallback(itemTouchCallback) {
 
     private val simpleSwipeCallback: SimpleSwipeDrawerCallback
     private var defaultSwipeDirs: Int = 0
 
     init {
         setDefaultSwipeDirs(swipeDirs)
-        simpleSwipeCallback = SimpleSwipeDrawerCallback(swipeDirs)
+        simpleSwipeCallback = SimpleSwipeDrawerCallback(swipeDirs, itemSwipeCallback)
     }
 
     override fun setDefaultSwipeDirs(defaultSwipeDirs: Int) {


### PR DESCRIPTION
Add an optional callback interface to `SimpleSwipeDrawerCallback`

  - `SimpleSwipeDrawerCallback.ItemSwipeCallback.itemSwiped` : Called when a drawer has been swiped (same bahaviour as `SimpleSwipeCallback.ItemSwipeCallback.itemSwiped`)

  - `SimpleSwipeDrawerCallback.ItemSwipeCallback.itemUnswiped` : Called when a drawer has been un-swiped (= returns to its default position)

+ update `SwipeDrawerListActivity` to log these events.