### PR TITLE
Kotlin 1.4.30 | Material components 1.3.0 | Gradle 6.8.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -113,10 +113,10 @@ dependencies {
     }
     //used to display the icons in the drawer
     //https://github.com/mikepenz/Android-Iconics
-    implementation 'com.mikepenz:material-design-iconic-typeface:2.2.0.6-kotlin@aar'
-    implementation 'com.mikepenz:community-material-typeface:5.3.45.1-kotlin@aar'
-    implementation 'com.mikepenz:google-material-typeface:3.0.1.4.original-kotlin@aar'
-    implementation 'com.mikepenz:fontawesome-typeface:5.9.0.0-kotlin@aar'
+    implementation 'com.mikepenz:material-design-iconic-typeface:2.2.0.8-kotlin@aar'
+    implementation 'com.mikepenz:community-material-typeface:5.8.55.0-kotlin@aar'
+    implementation 'com.mikepenz:google-material-typeface:4.0.0.1-kotlin@aar'
+    implementation 'com.mikepenz:fontawesome-typeface:5.9.0.2-kotlin@aar'
 
     //Used for the StickyHeaderSample
     //https://github.com/timehop/sticky-headers-recyclerview
@@ -179,6 +179,6 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "io.realm:realm-gradle-plugin:7.0.8"
+        classpath "io.realm:realm-gradle-plugin:10.3.1"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         ]
 
         setup = [
-                gradleTools: '4.1.1',
+                gradleTools: '4.1.2',
                 compileSdk : 30,
                 buildTools : "30.0.2",
                 minSdk     : 16,
@@ -19,25 +19,26 @@ buildscript {
         versions = [
                 androidX        : '1.1.0',
                 recyclerView    : '1.1.0',
-                material        : '1.2.1',
+                material        : '1.3.0',
                 appcompat       : '1.2.0',
                 drawerlayout    : '1.1.0',
                 constraintLayout: '2.0.4',
                 cardview        : '1.0.0',
-                kotlin          : '1.4.20',
-                iconics         : '5.1.1',
-                materialdrawer  : '8.2.0',
-                aboutlib        : '8.6.2',
-                roboelectric    : '4.4',
-                detekt          : '1.14.1',
+                kotlin          : '1.4.30',
+                iconics         : '5.2.5',
+                materialdrawer  : '8.3.1',
+                aboutlib        : '8.8.1',
+                roboelectric    : '4.5.1',
+                detekt          : '1.15.0',
                 paging          : "2.1.2",
-                room            : "2.2.5",
+                room            : "2.2.6",
                 lifecycle       : "2.2.0"
         ]
     }
 
     repositories {
         google()
+        mavenCentral()
         jcenter()
         maven {
             url "https://plugins.gradle.org/m2/"
@@ -56,6 +57,7 @@ allprojects {
 
     repositories {
         google()
+        mavenCentral()
         jcenter()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
         maven { url "https://jitpack.io" }
@@ -64,7 +66,7 @@ allprojects {
 }
 
 subprojects {
-    apply from: '../detekt.gradle'
+    apply from: "$rootDir/detekt.gradle"
 
     dependencies {
         detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:${versions.detekt}"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Thu Nov 26 13:16:08 CET 2020
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
- gradle 6.8.1
- build tools 4.1.2
- material components 1.3.0
- kotlin 1.4.30
- iconics 5.2.5
- update sample app font dependencies
- materialDrawer 8.3.1
- aboutLibs 8.8.1
- roboelectric 4.5.1
- detekt 1.15.0
- room 2.2.6
- include mavenCentral repo