### PR TITLE
Remove library reliance on jcenter | limit sample app repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           fetch-depth: 100
 
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+          java-package: jdk
+
       - name: Validate gradle wrapper
         uses: gradle/wrapper-validation-action@v1
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -145,7 +145,7 @@ dependencies {
 
     //Used to async operations
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
-    implementation 'io.reactivex.rxjava2:rxjava:2.2.20'
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.21'
 
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
 
@@ -172,6 +172,6 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "io.realm:realm-gradle-plugin:10.3.1"
+        classpath "io.realm:realm-gradle-plugin:10.4.0"
     }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,6 +67,23 @@ kapt {
     generateStubs = true
 }
 
+repositories {
+    maven {
+        url "https://jitpack.io"
+        content {
+            includeGroup "com.github.MFlisar"
+            includeGroup "com.github.turing-tech"
+        }
+    }
+    maven {
+        url "https://oss.sonatype.org/content/repositories/snapshots/"
+        content { includeGroup "com.mikepenz.thirdparty" }
+    }
+    jcenter() {
+        content { includeGroup "com.mopub" }
+    }
+}
+
 dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
 
@@ -152,9 +169,6 @@ dependencies {
     implementation "androidx.room:room-runtime:${versions.room}"
     kapt "androidx.room:room-compiler:${versions.room}"
 
-    implementation "androidx.lifecycle:lifecycle-extensions:${versions.lifecycle}"
-
-
     configurations.all {
         resolutionStrategy.force "com.mikepenz:iconics-core:${versions.iconics}"
         resolutionStrategy.force "com.mikepenz:iconics-views:${versions.iconics}"
@@ -169,8 +183,10 @@ dependencies {
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
+        jcenter() { content { includeGroup "io.realm" } }
     }
+
     dependencies {
         classpath "io.realm:realm-gradle-plugin:10.4.0"
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -169,7 +169,6 @@ dependencies {
 
 buildscript {
     repositories {
-        google()
         jcenter()
     }
     dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,7 +80,10 @@ repositories {
         content { includeGroup "com.mikepenz.thirdparty" }
     }
     jcenter() {
-        content { includeGroup "com.mopub" }
+        content {
+            includeGroup "com.mopub"
+            includeGroup "com.mopub.volley"
+        }
     }
 }
 

--- a/app/src/main/java/com/mikepenz/fastadapter/app/PagedActivity.kt
+++ b/app/src/main/java/com/mikepenz/fastadapter/app/PagedActivity.kt
@@ -3,9 +3,7 @@ package com.mikepenz.fastadapter.app
 import android.os.Bundle
 import android.os.Handler
 import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
-import androidx.paging.PagedList
+import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.AsyncDifferConfig
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -69,12 +67,11 @@ class PagedActivity : AppCompatActivity() {
         binding.rv.layoutManager = LinearLayoutManager(this)
         binding.rv.adapter = mFastAdapter
 
-        val viewModel = ViewModelProviders.of(this,
-                DemoEntityViewModel.DemoEntityViewModelFactory(this.application))
-                .get(DemoEntityViewModel::class.java)
+        val viewModel = ViewModelProvider(this, DemoEntityViewModel.DemoEntityViewModelFactory(this.application))
+            .get(DemoEntityViewModel::class.java)
 
         //listen to data changes and pass it to adapter for displaying in recycler view
-        viewModel.demoEntitiesList.observe(this, Observer<PagedList<DemoEntity>> { t -> mItemAdapter.submitList(t!!) })
+        viewModel.demoEntitiesList.observe(this, { t -> mItemAdapter.submitList(t!!) })
 
         //if we do this. the first added items will be animated :D
         Handler().postDelayed({

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         ]
 
         setup = [
-                gradleTools: '4.1.2',
+                gradleTools: '4.1.3',
                 compileSdk : 30,
                 buildTools : "30.0.2",
                 minSdk     : 16,
@@ -18,30 +18,28 @@ buildscript {
 
         versions = [
                 androidX        : '1.1.0',
-                recyclerView    : '1.1.0',
+                recyclerView    : '1.2.0',
                 material        : '1.3.0',
                 appcompat       : '1.2.0',
                 drawerlayout    : '1.1.0',
                 constraintLayout: '2.0.4',
                 cardview        : '1.0.0',
-                kotlin          : '1.4.30',
-                iconics         : '5.2.5',
-                materialdrawer  : '8.3.2',
-                aboutlib        : '8.8.1',
+                kotlin          : '1.4.32',
+                iconics         : '5.2.8',
+                materialdrawer  : '8.4.0',
+                aboutlib        : '8.8.4',
                 roboelectric    : '4.5.1',
-                detekt          : '1.15.0',
+                detekt          : '1.16.0',
                 paging          : "2.1.2",
                 room            : "2.2.6",
-                lifecycle       : "2.2.0"
+                lifecycle       : "2.3.1"
         ]
     }
 
     repositories {
-        google()
+        gradlePluginPortal()
         mavenCentral()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
+        google()
     }
     dependencies {
         classpath "com.android.tools.build:gradle:${setup.gradleTools}"
@@ -55,9 +53,18 @@ allprojects {
     group "com.mikepenz"
 
     repositories {
-        google()
         mavenCentral()
-        jcenter()
+        google()
+        maven {
+            // (mp) remove when available on maven center
+            url "https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven"
+            content { includeGroup "org.jetbrains.kotlinx" }
+        }
+    }
+
+    configurations.all {
+        resolutionStrategy.force "org.jetbrains.kotlinx:kotlinx-html-jvm:0.7.3"
+        // (mp) remove when available on maven center
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
                 cardview        : '1.0.0',
                 kotlin          : '1.4.30',
                 iconics         : '5.2.5',
-                materialdrawer  : '8.3.1',
+                materialdrawer  : '8.3.2',
                 aboutlib        : '8.8.1',
                 roboelectric    : '4.5.1',
                 detekt          : '1.15.0',
@@ -39,7 +39,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -59,9 +58,6 @@ allprojects {
         google()
         mavenCentral()
         jcenter()
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
-        maven { url "https://jitpack.io" }
-        maven { url "https://dl.bintray.com/mikepenz/maven" }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,5 +18,5 @@ POM_DEVELOPER_ID=mikepenz
 POM_DEVELOPER_NAME=Mike Penz
 
 android.useAndroidX=true
-android.enableJetifier=false
+android.enableJetifier=true
 org.gradle.jvmargs=-Xmx4G

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,7 @@ POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
 POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=mikepenz
 POM_DEVELOPER_NAME=Mike Penz
+
 android.useAndroidX=true
-android.enableJetifier=true
+android.enableJetifier=false
 org.gradle.jvmargs=-Xmx4G

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- update materialdrawer 8.3.2
- ci pipeline java 11
- disable jetifier
- androidx multidex
-  more dependency updates 
   - recyclerView 1.2.0
   - kotlin 1.4.32
   - build tools 4.1.3
   - iconics, materialdrawer, aboutlibs, detekt
   - lifecycle 2.3.1
-----

Sadly as of the time speaking realm, mopub, ... all still depend on jcenter. re-evaluate at a later point