### PR TITLE
Ghost after drag and drop

### DIFF
--- a/fastadapter-extensions-drag/src/main/java/com/mikepenz/fastadapter/drag/SimpleDragCallback.kt
+++ b/fastadapter-extensions-drag/src/main/java/com/mikepenz/fastadapter/drag/SimpleDragCallback.kt
@@ -103,6 +103,14 @@ open class SimpleDragCallback : ItemTouchHelper.SimpleCallback {
     override fun clearView(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder) {
         super.clearView(recyclerView, viewHolder)
         callbackItemTouch?.itemTouchStopDrag(viewHolder)
+        if (notifyAllDrops || from != RecyclerView.NO_POSITION && to != RecyclerView.NO_POSITION) {
+            // If 'to' is not set, then we can assume the item hasn't moved at all
+            if (from != RecyclerView.NO_POSITION && to == RecyclerView.NO_POSITION) to = from
+            callbackItemTouch?.itemTouchDropped(from, to)
+        }
+        // reset the from/to positions
+        to = RecyclerView.NO_POSITION
+        from = RecyclerView.NO_POSITION
     }
 
     override fun onSelectedChanged(viewHolder: RecyclerView.ViewHolder?, actionState: Int) {
@@ -110,15 +118,6 @@ open class SimpleDragCallback : ItemTouchHelper.SimpleCallback {
         if (ItemTouchHelper.ACTION_STATE_DRAG == actionState && viewHolder != null) {
             from = viewHolder.adapterPosition
             callbackItemTouch?.itemTouchStartDrag(viewHolder)
-        } else if (actionState == ItemTouchHelper.ACTION_STATE_IDLE) {
-            if (notifyAllDrops || from != RecyclerView.NO_POSITION && to != RecyclerView.NO_POSITION) {
-                // If 'to' is not set, then we can assume the item hasn't moved at all
-                if (from != RecyclerView.NO_POSITION && to == RecyclerView.NO_POSITION) to = from
-                callbackItemTouch?.itemTouchDropped(from, to)
-            }
-            // reset the from/to positions
-            to = RecyclerView.NO_POSITION
-            from = RecyclerView.NO_POSITION
         }
     }
 


### PR DESCRIPTION
I was excited of [this](https://github.com/mikepenz/FastAdapter/pull/985) because I implemented the same `itemTouchStopDrag` method locally to clear visuals after I dropped the item, however after this change my list is having a ghost effect. 

In my `itemTouchDropped` method I update my DB and that triggers a new list being set to FastAdapter with `itemAdapter.set(newList)`. According to my logs, the list is being set before `itemTouchStopDrag` is called.
```
D/AccountListFragment: ITEM TOUCH ON MOVE
D/AccountListFragment: ITEM TOUCH ON MOVE
D/AccountListFragment: ITEM TOUCH DROPPED
D/AccountListFragment$bindViewModel: SET NEW LIST
D/AccountListFragment: ITEM TOUCH STOP DRAG
```

Here is a video of what is happening:
https://user-images.githubusercontent.com/808267/114277375-cafbd780-9a22-11eb-9052-54f21f0b17a8.mp4


