### PR TITLE
Fix `ISubItem`  not allowed to have only 1 item expanded

### DIFF
--- a/fastadapter-extensions-expandable/src/main/java/com/mikepenz/fastadapter/expandable/ExpandableExtension.kt
+++ b/fastadapter-extensions-expandable/src/main/java/com/mikepenz/fastadapter/expandable/ExpandableExtension.kt
@@ -38,8 +38,8 @@ internal fun <R> IItem<out RecyclerView.ViewHolder>?.ifExpandable(block: (IExpan
 }
 
 /** Internal helper function to execute the block if the item is expandable */
-internal fun <R> IItem<out RecyclerView.ViewHolder>?.ifExpandableParent(block: (IExpandable<*>, IParentItem<*>) -> R): R? {
-    return (this as? IExpandable<*>)?.parent?.let {
+internal fun <R> IItem<out RecyclerView.ViewHolder>?.ifExpandableParent(block: (ISubItem<*>, IParentItem<*>) -> R): R? {
+    return (this as? ISubItem<*>)?.parent?.let {
         block.invoke(this, it)
     }
 }


### PR DESCRIPTION
- lower requirement for expandable parent detection to `ISubItem` (a subitem should not be required to be a `IExpandable`)