### PR TITLE
Drop `network_security_config` from sample app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,6 @@
             android:allowBackup="true"
             android:icon="@mipmap/ic_launcher"
             android:label="@string/app_name"
-            android:networkSecurityConfig="@xml/network_security_config"
             android:roundIcon="@mipmap/ic_launcher_round"
             android:theme="@style/SampleApp.DayNight"
             tools:ignore="GoogleAppIndexingWarning">

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<network-security-config>
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">ads.mopub.com</domain>
-    </domain-config>
-</network-security-config>


### PR DESCRIPTION
- drop networksecurity config from sample app (which has no more mopub)
  - FIX https://github.com/mikepenz/FastAdapter/issues/1043