### PR TITLE
Polish GHA config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 100
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
           java-version: '11'
-          java-package: jdk
+          distribution: 'zulu'
 
       - name: Validate gradle wrapper
         uses: gradle/wrapper-validation-action@v1
@@ -28,17 +28,8 @@ jobs:
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-      - name: Checkout Gradle Build Cache
-        if: ${{ steps.self_hosted.outputs.FLAG != 'self-hosted' }}
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            !~/.gradle/wrapper/dists/**/gradle*.zip
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-
+      - name: Gradle Build Cache
+        uses: gradle/gradle-build-action@v2
 
       - name: Build Debug
         run: ./gradlew clean app:assembleDebug
@@ -114,7 +105,7 @@ jobs:
           find . -name "*.aab" -type f -exec cp {} "artifacts" \;
 
       - name: Archive Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: "App-Artifacts"
           path: artifacts/*


### PR DESCRIPTION
- Bump actions, some of them are deprecated.
- Use more [gradle/gradle-build-action@v2](https://github.com/gradle/gradle-build-action) to cache Gradle.